### PR TITLE
Block dangerous file extensions on upload by default

### DIFF
--- a/config/mediaman.php
+++ b/config/mediaman.php
@@ -72,6 +72,25 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Disallowed File Extensions
+    |--------------------------------------------------------------------------
+    |
+    | File extensions that are blocked from upload for security reasons.
+    | These are checked regardless of the MIME type validation.
+    |
+    | Set `block_disallowed_extensions` to false to disable this check.
+    |
+    */
+
+    'block_disallowed_extensions' => true,
+
+    'disallowed_extensions' => [
+        'php', 'phtml', 'phar', 'shtml', 'htaccess',
+        'cgi', 'pl', 'asp', 'aspx', 'jsp', 'jspx',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | The queue that should be used to perform image conversions
     |--------------------------------------------------------------------------
     |

--- a/src/Exceptions/DisallowedExtension.php
+++ b/src/Exceptions/DisallowedExtension.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Emaia\MediaMan\Exceptions;
+
+use Exception;
+
+class DisallowedExtension extends Exception
+{
+    public static function forExtension(string $extension): self
+    {
+        return new self("The file extension `.{$extension}` is not allowed for upload.");
+    }
+}

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -4,6 +4,7 @@ namespace Emaia\MediaMan;
 
 use Emaia\MediaMan\Enums\MediaType;
 use Emaia\MediaMan\Events\MediaUploaded;
+use Emaia\MediaMan\Exceptions\DisallowedExtension;
 use Emaia\MediaMan\Exceptions\FileSizeExceeded;
 use Emaia\MediaMan\Exceptions\MimeTypeNotAllowed;
 use Emaia\MediaMan\Models\Media;
@@ -222,6 +223,7 @@ class MediaUploader
      */
     public function upload(): Media
     {
+        $this->validateExtension();
         $this->validateMimeType();
         $this->validateFileSize();
 
@@ -357,6 +359,38 @@ class MediaUploader
         if ($actualBytes > $maxBytes) {
             throw FileSizeExceeded::forSize($actualBytes, $maxBytes);
         }
+    }
+
+    /**
+     * Validate the file extension against disallowed extensions.
+     *
+     * @throws DisallowedExtension
+     */
+    protected function validateExtension(): void
+    {
+        if (! config('mediaman.block_disallowed_extensions', true)) {
+            return;
+        }
+
+        $disallowed = $this->getDisallowedExtensions();
+
+        if (empty($disallowed)) {
+            return;
+        }
+
+        $extension = strtolower(pathinfo($this->fileName, PATHINFO_EXTENSION));
+
+        if ($extension !== '' && in_array($extension, $disallowed, true)) {
+            throw DisallowedExtension::forExtension($extension);
+        }
+    }
+
+    protected function getDisallowedExtensions(): array
+    {
+        return config('mediaman.disallowed_extensions') ?? [
+            'php', 'phtml', 'phar', 'shtml', 'htaccess',
+            'cgi', 'pl', 'asp', 'aspx', 'jsp', 'jspx',
+        ];
     }
 
     /**

--- a/tests/Feature/DisallowedExtensionTest.php
+++ b/tests/Feature/DisallowedExtensionTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use Emaia\MediaMan\Exceptions\DisallowedExtension;
+use Emaia\MediaMan\MediaUploader;
+use Emaia\MediaMan\Models\Media;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+
+it('blocks uploads with default disallowed extension', function () {
+    $file = UploadedFile::fake()->create('shell.php', 100);
+
+    MediaUploader::source($file)->upload();
+})->throws(DisallowedExtension::class);
+
+it('blocks uploads with all default disallowed extensions', function (string $ext) {
+    $file = UploadedFile::fake()->create("evil.{$ext}", 100);
+
+    MediaUploader::source($file)->upload();
+})->throws(DisallowedExtension::class)->with([
+    'php', 'phtml', 'phar', 'shtml', 'htaccess',
+    'cgi', 'pl', 'asp', 'aspx', 'jsp', 'jspx',
+]);
+
+it('allows uploads with common safe extensions', function () {
+    $file = UploadedFile::fake()->image('photo.jpg');
+
+    $media = MediaUploader::source($file)->upload();
+
+    expect($media)->toBeInstanceOf(Media::class)
+        ->and($media->file_name)->toEndWith('.jpg');
+});
+
+it('blocks disallowed extensions case-insensitively', function () {
+    $file = UploadedFile::fake()->create('shell.PHP', 100);
+
+    MediaUploader::source($file)->upload();
+})->throws(DisallowedExtension::class);
+
+it('allows disallowed extensions when block_disallowed_extensions is false', function () {
+    Config::set('mediaman.block_disallowed_extensions', false);
+
+    $file = UploadedFile::fake()->create('shell.php', 100);
+
+    $media = MediaUploader::source($file)->upload();
+
+    expect($media)->toBeInstanceOf(Media::class)
+        ->and($media->file_name)->toEndWith('.php');
+});
+
+it('allows all extensions when disallowed_extensions list is empty', function () {
+    Config::set('mediaman.disallowed_extensions', []);
+
+    $file = UploadedFile::fake()->create('shell.php', 100);
+
+    $media = MediaUploader::source($file)->upload();
+
+    expect($media)->toBeInstanceOf(Media::class);
+});
+
+it('does not save media to database when extension is blocked', function () {
+    $before = Media::count();
+
+    try {
+        MediaUploader::source(UploadedFile::fake()->create('shell.php', 100))->upload();
+    } catch (DisallowedExtension) {
+        // expected
+    }
+
+    expect(Media::count())->toEqual($before);
+});
+
+it('does not store file to disk when extension is blocked', function () {
+    try {
+        MediaUploader::source(UploadedFile::fake()->create('shell.php', 100))->upload();
+    } catch (DisallowedExtension) {
+        // expected
+    }
+
+    expect(Storage::disk(self::DEFAULT_DISK)->allFiles())->toBeEmpty();
+});
+
+it('blocks disallowed extension when set via useFileName', function () {
+    $file = UploadedFile::fake()->image('photo.jpg');
+
+    MediaUploader::source($file)
+        ->useFileName('malware.php')
+        ->upload();
+})->throws(DisallowedExtension::class);
+
+it('blocks bare dotfile like .htaccess', function () {
+    MediaUploader::source(UploadedFile::fake()->create('.htaccess', 100))->upload();
+})->throws(DisallowedExtension::class);
+
+it('includes the extension in the exception message', function () {
+    try {
+        MediaUploader::source(UploadedFile::fake()->create('evil.php', 100))->upload();
+        $this->fail('Expected DisallowedExtension to be thrown');
+    } catch (DisallowedExtension $e) {
+        expect($e->getMessage())->toContain('php');
+    }
+});

--- a/tests/Feature/MediaUploaderTest.php
+++ b/tests/Feature/MediaUploaderTest.php
@@ -93,6 +93,14 @@ it('sanitizes double extensions', function () {
     expect($media->file_name)->toEqual('malware-php.jpg');
 });
 
+it('sanitization defuses double-extension before validation runs', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->create('legit.php.jpg', 100))->upload();
+
+    expect($media)->toBeInstanceOf(Media::class)
+        ->and($media->file_name)->not->toContain('.php')
+        ->and($media->file_name)->toEndWith('.jpg');
+});
+
 it('strips unicode control characters from file name', function () {
     $media = MediaUploader::source(UploadedFile::fake()->image('file.jpg'))
         ->useFileName("file\xE2\x80\x8Bname.jpg")  // zero-width space


### PR DESCRIPTION
## Summary

- Block dangerous file extensions by default (php, phtml, phar, shtml, htaccess, cgi, pl, asp*, jsp*)
- Add `block_disallowed_extensions` config flag for opt-out
- Throw `DisallowedExtension` before any DB write or disk write
- Validate against sanitized filename so `.php.jpg` style attacks are defused before the check runs

## Breaking behavior

- Uploads with disallowed extensions now throw `DisallowedExtension`. Set
  `mediaman.block_disallowed_extensions = false` (or publish the config and clear the list) to restore previous behavior.

## Test plan

- [x] `composer test` — 380/380 passing
- [x] `composer analyse` — clean
- [x] Manual smoke: upload `.php`, confirm `DisallowedExtension` thrown
- [x] Manual smoke: set `block_disallowed_extensions=false`, upload `.php`, confirm accepted
- [x] Manual smoke: upload `legit.php.jpg`, confirm sanitized to `legit-php.jpg` and accepted