### PR TITLE
Add UrlGuard with SSRF protection for remote URL sources

### DIFF
--- a/config/mediaman.php
+++ b/config/mediaman.php
@@ -91,6 +91,82 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | URL Source Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Settings for downloading files from remote URLs (fromUrl).
+    |
+    */
+
+    'url_sources' => [
+
+        /*
+        |--------------------------------------------------------------------------
+        | Allow Private Hosts
+        |--------------------------------------------------------------------------
+        |
+        | When false, URLs that resolve to private or reserved IP addresses
+        | (localhost, 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16,
+        | 169.254.0.0/16) will be rejected to prevent SSRF attacks.
+        |
+        | Set to true when your app needs to download from internal networks.
+        |
+        */
+
+        'allow_private_hosts' => false,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Timeout (seconds)
+        |--------------------------------------------------------------------------
+        |
+        | Maximum time to wait for a response when downloading a file from
+        | a remote URL.
+        |
+        */
+
+        'timeout_seconds' => 30,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Maximum Download Size (bytes)
+        |--------------------------------------------------------------------------
+        |
+        | Maximum file size to download from a remote URL. Default is 100 MB.
+        | Downloads exceeding this limit will be aborted mid-stream.
+        |
+        */
+
+        'max_size_bytes' => 100 * 1024 * 1024,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Verify SSL Certificates
+        |--------------------------------------------------------------------------
+        |
+        | When true, SSL certificates presented by the remote server will be
+        | verified. Set to false only for development or internal APIs with
+        | self-signed certificates.
+        |
+        */
+
+        'verify_ssl' => true,
+
+        /*
+        |--------------------------------------------------------------------------
+        | User Agent
+        |--------------------------------------------------------------------------
+        |
+        | The User-Agent header sent with remote download requests.
+        |
+        */
+
+        'user_agent' => 'MediaMan/2.x',
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | The queue that should be used to perform image conversions
     |--------------------------------------------------------------------------
     |

--- a/src/Exceptions/UrlNotAllowed.php
+++ b/src/Exceptions/UrlNotAllowed.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Emaia\MediaMan\Exceptions;
+
+use Exception;
+
+class UrlNotAllowed extends Exception
+{
+    public static function forScheme(string $scheme): self
+    {
+        return new self("URL scheme [$scheme] is not allowed.");
+    }
+
+    public static function noHost(): self
+    {
+        return new self('URL has no valid host.');
+    }
+
+    public static function forHost(string $host): self
+    {
+        return new self("URL host [$host] is not allowed.");
+    }
+
+    public static function forPrivateIp(string $host): self
+    {
+        return new self("URL host [$host] resolves to a private or reserved IP address.");
+    }
+}

--- a/src/Support/UrlGuard.php
+++ b/src/Support/UrlGuard.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Emaia\MediaMan\Support;
+
+use Emaia\MediaMan\Exceptions\UrlNotAllowed;
+
+class UrlGuard
+{
+    private const array ALLOWED_SCHEMES = ['http', 'https'];
+
+    private const array BLOCKED_HOSTS = ['localhost', 'localhost.'];
+
+    private const array PRIVATE_IPV4_RANGES = [
+        ['0.0.0.0', '0.255.255.255'],
+        ['10.0.0.0', '10.255.255.255'],
+        ['127.0.0.0', '127.255.255.255'],
+        ['169.254.0.0', '169.254.255.255'],
+        ['172.16.0.0', '172.31.255.255'],
+        ['192.168.0.0', '192.168.255.255'],
+    ];
+
+    private const array BLOCKED_IPV4_SINGLE = [
+        '255.255.255.255',
+    ];
+
+    public static function check(string $url): void
+    {
+        $parts = @parse_url($url);
+
+        if ($parts === false || ! isset($parts['host'])) {
+            throw UrlNotAllowed::noHost();
+        }
+
+        $scheme = isset($parts['scheme']) ? strtolower($parts['scheme']) : null;
+
+        if ($scheme === null || ! in_array($scheme, self::ALLOWED_SCHEMES, true)) {
+            throw UrlNotAllowed::forScheme($scheme ?? 'null');
+        }
+
+        $host = strtolower($parts['host']);
+
+        if ($host === '') {
+            throw UrlNotAllowed::noHost();
+        }
+
+        self::checkHost($host);
+    }
+
+    private static function checkHost(string $host): void
+    {
+        if (in_array($host, self::BLOCKED_HOSTS, true) || str_ends_with($host, '.localhost')) {
+            if (! config('mediaman.url_sources.allow_private_hosts', false)) {
+                throw UrlNotAllowed::forHost($host);
+            }
+
+            return;
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            self::checkIPv4($host);
+
+            return;
+        }
+
+        $ipv6Host = str_starts_with($host, '[') ? trim($host, '[]') : $host;
+
+        if (filter_var($ipv6Host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+            self::checkIPv6($ipv6Host);
+
+            return;
+        }
+
+        if (config('mediaman.url_sources.allow_private_hosts', false)) {
+            return;
+        }
+
+        $resolvedIps = self::resolveHost($host);
+
+        foreach ($resolvedIps as $ip) {
+            self::checkResolvedIp($ip);
+        }
+    }
+
+    private static function checkIPv4(string $ip): void
+    {
+        if (config('mediaman.url_sources.allow_private_hosts', false)) {
+            return;
+        }
+
+        if (in_array($ip, self::BLOCKED_IPV4_SINGLE, true)) {
+            throw UrlNotAllowed::forPrivateIp($ip);
+        }
+
+        $ipLong = ip2long($ip);
+
+        foreach (self::PRIVATE_IPV4_RANGES as $range) {
+            $start = ip2long($range[0]);
+            $end = ip2long($range[1]);
+
+            if ($ipLong >= $start && $ipLong <= $end) {
+                throw UrlNotAllowed::forPrivateIp($ip);
+            }
+        }
+    }
+
+    private static function checkIPv6(string $ip): void
+    {
+        if (config('mediaman.url_sources.allow_private_hosts', false)) {
+            return;
+        }
+
+        $binary = inet_pton($ip);
+
+        if ($binary === false) {
+            return;
+        }
+
+        // ::/128 (unspecified)
+        if ($binary === inet_pton('::')) {
+            throw UrlNotAllowed::forPrivateIp($ip);
+        }
+
+        // ::1/128 (loopback)
+        if ($binary === inet_pton('::1')) {
+            throw UrlNotAllowed::forPrivateIp($ip);
+        }
+
+        // ::ffff:x.x.x.x/96 (IPv4-mapped)
+        if (self::isIPv4Mapped($binary)) {
+            $ipv4 = long2ip(unpack('N', substr($binary, 12, 4))[1]);
+
+            self::checkIPv4($ipv4);
+
+            return;
+        }
+
+        $firstByte = ord($binary[0]);
+
+        // fc00::/7 (Unique Local Addresses)
+        if (($firstByte & 0xFE) === 0xFC) {
+            throw UrlNotAllowed::forPrivateIp($ip);
+        }
+
+        // fe80::/10 (link-local)
+        $secondByte = ord($binary[1]);
+
+        if ($firstByte === 0xFE && ($secondByte & 0xC0) === 0x80) {
+            throw UrlNotAllowed::forPrivateIp($ip);
+        }
+
+        // 2002::/16 (6to4 tunnel)
+        if ($firstByte === 0x20 && $secondByte === 0x02) {
+            throw UrlNotAllowed::forPrivateIp($ip);
+        }
+
+        // 2001::/32 (Teredo tunnel)
+        if ($firstByte === 0x20 && $secondByte === 0x01 && ord($binary[2]) === 0x00 && ord($binary[3]) === 0x00) {
+            throw UrlNotAllowed::forPrivateIp($ip);
+        }
+    }
+
+    private static function isIPv4Mapped(string $binary): bool
+    {
+        return strlen($binary) === 16
+            && ord($binary[10]) === 0xFF
+            && ord($binary[11]) === 0xFF
+            && substr($binary, 0, 10) === str_repeat("\x00", 10);
+    }
+
+    /**
+     * @return string[]
+     *
+     * TODO(2.4): pin resolved IPs in HttpDownloader via CURLOPT_RESOLVE
+     * to prevent DNS rebinding between this check and the actual fetch.
+     */
+    private static function resolveHost(string $host): array
+    {
+        $ips = [];
+
+        $ipv4List = @gethostbynamel($host);
+
+        if ($ipv4List !== false) {
+            foreach ($ipv4List as $ip) {
+                $ips[] = $ip;
+            }
+        }
+
+        $aaaaRecords = @dns_get_record($host, DNS_AAAA);
+
+        if (is_array($aaaaRecords)) {
+            foreach ($aaaaRecords as $record) {
+                if (isset($record['ipv6'])) {
+                    $ips[] = $record['ipv6'];
+                }
+            }
+        }
+
+        return $ips;
+    }
+
+    private static function checkResolvedIp(string $ip): void
+    {
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            self::checkIPv4($ip);
+        } elseif (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+            self::checkIPv6($ip);
+        }
+    }
+}

--- a/tests/Feature/UrlGuardTest.php
+++ b/tests/Feature/UrlGuardTest.php
@@ -1,0 +1,185 @@
+<?php
+
+use Emaia\MediaMan\Exceptions\UrlNotAllowed;
+use Emaia\MediaMan\Support\UrlGuard;
+use Illuminate\Support\Facades\Config;
+
+beforeEach(function () {
+    Config::set('mediaman.url_sources.allow_private_hosts', false);
+});
+
+// --- Scheme validation ---
+
+it('allows standard http URL', function () {
+    UrlGuard::check('https://example.com/file.jpg');
+})->throwsNoExceptions();
+
+it('allows standard https URL', function () {
+    UrlGuard::check('https://example.com/file.jpg');
+})->throwsNoExceptions();
+
+it('rejects ftp scheme', function () {
+    UrlGuard::check('ftp://example.com/file.txt');
+})->throws(UrlNotAllowed::class);
+
+it('rejects file scheme', function () {
+    UrlGuard::check('file:///etc/passwd');
+})->throws(UrlNotAllowed::class);
+
+it('rejects URL with no scheme', function () {
+    UrlGuard::check('//example.com/file.jpg');
+})->throws(UrlNotAllowed::class);
+
+// --- Hostname blocking ---
+
+it('rejects localhost hostname', function () {
+    UrlGuard::check('http://localhost/admin');
+})->throws(UrlNotAllowed::class);
+
+it('rejects localhost with trailing dot', function () {
+    UrlGuard::check('http://localhost./admin');
+})->throws(UrlNotAllowed::class);
+
+it('rejects subdomain of localhost', function () {
+    UrlGuard::check('http://app.localhost/admin');
+})->throws(UrlNotAllowed::class);
+
+// --- IPv4 private ranges ---
+
+it('rejects 127.0.0.1 loopback', function () {
+    UrlGuard::check('http://127.0.0.1/api');
+})->throws(UrlNotAllowed::class);
+
+it('rejects 10.x.x.x private range', function () {
+    UrlGuard::check('http://10.0.0.1/api');
+})->throws(UrlNotAllowed::class);
+
+it('rejects 172.16.x.x private range start', function () {
+    UrlGuard::check('http://172.16.0.1/api');
+})->throws(UrlNotAllowed::class);
+
+it('rejects 172.31.x.x private range end', function () {
+    UrlGuard::check('http://172.31.255.254/api');
+})->throws(UrlNotAllowed::class);
+
+it('rejects 192.168.x.x private range', function () {
+    UrlGuard::check('http://192.168.1.1/api');
+})->throws(UrlNotAllowed::class);
+
+it('rejects 169.254.x.x AWS/GCP metadata range', function () {
+    UrlGuard::check('http://169.254.169.254/latest/meta-data/');
+})->throws(UrlNotAllowed::class);
+
+it('rejects 0.0.0.0', function () {
+    UrlGuard::check('http://0.0.0.0/api');
+})->throws(UrlNotAllowed::class);
+
+it('rejects 255.255.255.255 broadcast', function () {
+    UrlGuard::check('http://255.255.255.255/api');
+})->throws(UrlNotAllowed::class);
+
+// --- IPv6 blocking ---
+
+it('rejects IPv6 loopback ::1', function () {
+    UrlGuard::check('http://[::1]/api');
+})->throws(UrlNotAllowed::class);
+
+it('rejects IPv6 unspecified ::', function () {
+    UrlGuard::check('http://[::]/api');
+})->throws(UrlNotAllowed::class);
+
+it('rejects IPv6 link-local fe80::', function () {
+    UrlGuard::check('http://[fe80::1]/api');
+})->throws(UrlNotAllowed::class);
+
+it('rejects IPv6 unique local fc00::', function () {
+    UrlGuard::check('http://[fc00::1]/api');
+})->throws(UrlNotAllowed::class);
+
+it('rejects IPv6 unique local fd00::', function () {
+    UrlGuard::check('http://[fd00::1]/api');
+})->throws(UrlNotAllowed::class);
+
+it('rejects IPv4-mapped IPv6 ::ffff:127.0.0.1', function () {
+    UrlGuard::check('http://[::ffff:127.0.0.1]/api');
+})->throws(UrlNotAllowed::class);
+
+it('rejects 6to4 tunnel 2002::', function () {
+    UrlGuard::check('http://[2002::1]/api');
+})->throws(UrlNotAllowed::class);
+
+it('rejects Teredo tunnel 2001::', function () {
+    UrlGuard::check('http://[2001::1]/api');
+})->throws(UrlNotAllowed::class);
+
+// --- URL with no host ---
+
+it('rejects URL with no host', function () {
+    UrlGuard::check('http://');
+})->throws(UrlNotAllowed::class);
+
+// --- allow_private_hosts bypass ---
+
+it('allows localhost when allow_private_hosts is true', function () {
+    Config::set('mediaman.url_sources.allow_private_hosts', true);
+
+    UrlGuard::check('http://localhost/admin');
+})->throwsNoExceptions();
+
+it('allows 127.0.0.1 when allow_private_hosts is true', function () {
+    Config::set('mediaman.url_sources.allow_private_hosts', true);
+
+    UrlGuard::check('http://127.0.0.1/api');
+})->throwsNoExceptions();
+
+it('allows 10.x.x.x when allow_private_hosts is true', function () {
+    Config::set('mediaman.url_sources.allow_private_hosts', true);
+
+    UrlGuard::check('http://10.0.0.1/api');
+})->throwsNoExceptions();
+
+it('allows 169.254.169.254 when allow_private_hosts is true', function () {
+    Config::set('mediaman.url_sources.allow_private_hosts', true);
+
+    UrlGuard::check('http://169.254.169.254/metadata');
+})->throwsNoExceptions();
+
+// --- DNS resolution ---
+
+it('rejects host that resolves to a private IP via DNS', function () {
+    Config::set('mediaman.url_sources.allow_private_hosts', false);
+
+    UrlGuard::check('http://localhost.localdomain/api');
+})->throws(UrlNotAllowed::class);
+
+it('rejects host with mixed public and private A records', function () {
+    Config::set('mediaman.url_sources.allow_private_hosts', false);
+
+    $resolved = gethostbynamel('localhost.localdomain');
+
+    if ($resolved === false || count($resolved) < 2) {
+        $this->markTestSkipped('localhost.localdomain did not return multiple IPs in this environment.');
+    }
+
+    UrlGuard::check('http://localhost.localdomain/api');
+})->throws(UrlNotAllowed::class);
+
+// --- Exception messages ---
+
+it('includes the scheme in the rejection message', function () {
+    try {
+        UrlGuard::check('ftp://example.com/file');
+        $this->fail('Expected UrlNotAllowed to be thrown');
+    } catch (UrlNotAllowed $e) {
+        expect($e->getMessage())->toContain('ftp');
+    }
+});
+
+it('includes the host in the rejection message', function () {
+    try {
+        UrlGuard::check('http://127.0.0.1/api');
+        $this->fail('Expected UrlNotAllowed to be thrown');
+    } catch (UrlNotAllowed $e) {
+        expect($e->getMessage())->toContain('127.0.0.1');
+    }
+});


### PR DESCRIPTION
## Summary

- Add `UrlGuard::check()` utility for validating remote URLs against SSRF attacks
- Scheme allowlist: only `http` and `https`
- IPv4 blocks: 0.0.0.0/8, 10.0.0.0/8, 127.0.0.0/8, 169.254.0.0/16 (AWS/GCP metadata), 172.16.0.0/12, 192.168.0.0/16, 255.255.255.255 broadcast
- IPv6 blocks: `::`, `::1`, `fc00::/7` (ULA), `fe80::/10` (link-local), `::ffff:x.x.x.x` (IPv4-mapped delegates to IPv4 check), `2002::/16` (6to4), `2001::/32` (Teredo)
- DNS resolution covers both A and AAAA records, rejects if **any** resolved IP is private
- Opt-out via `mediaman.url_sources.allow_private_hosts = true`
- `UrlNotAllowed` exception follows existing package convention (factory methods)
- `url_sources` config block ready for 2.4 `fromUrl()`: timeout, max_size_bytes, verify_ssl, user_agent

Standalone guard — not yet wired into uploads. Will be consumed by `MediaUploader::fromUrl()` in 2.4.

## Notes

- `TODO(2.4)` left in `resolveHost()` to remind us to pin resolved IPs via `CURLOPT_RESOLVE` in `HttpDownloader`, mitigating DNS rebinding between check time and fetch time.

## Test plan

- [x] `composer test` — 413/413 (1 skip is environment-dependent)
- [x] `composer analyse` — clean
- [x] Manual smoke: `UrlGuard::check('http://169.254.169.254/')` → throws
- [x] Manual smoke: `UrlGuard::check('http://localhost/')` → throws
- [x] Manual smoke: `UrlGuard::check('http://[fc00::1]/')` → throws
- [x] Manual smoke: `UrlGuard::check('https://example.com/file.jpg')` → passes
- [x] Manual smoke: set `allow_private_hosts=true`, retry localhost → passes