### PR TITLE
Add mediaman:clean command to detect orphaned files and records

### DIFF
--- a/src/Console/Commands/MediamanCleanCommand.php
+++ b/src/Console/Commands/MediamanCleanCommand.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Emaia\MediaMan\Console\Commands;
+
+use Emaia\MediaMan\Models\Media;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+
+class MediamanCleanCommand extends Command
+{
+    protected $signature = 'mediaman:clean
+                            {--force : Actually delete orphaned files on disk (DB records are never auto-deleted)}
+                            {--disk= : Specific disk to scan}';
+
+    protected $description = 'Detect orphaned files on disk and records with missing files.
+Orphan detection uses top-level media directories — stale conversion
+or responsive files within a valid media directory are not flagged.';
+
+    public function handle(): int
+    {
+        $diskName = $this->option('disk') ?? config('mediaman.disk');
+        $dryRun = ! $this->option('force');
+
+        try {
+            $filesystem = Storage::disk($diskName);
+        } catch (InvalidArgumentException $e) {
+            $this->error("Disk [$diskName] is not defined in the filesystems configuration.");
+
+            return 1;
+        }
+
+        $mediaRecords = Media::where('disk', $diskName)->get();
+
+        $knownDirs = [];
+
+        foreach ($mediaRecords as $media) {
+            $knownDirs[$media->getDirectory()] = true;
+        }
+
+        // 1. Find orphaned files (files on disk without a matching Media record)
+        $allFiles = $filesystem->allFiles();
+        $orphanedFiles = [];
+
+        foreach ($allFiles as $file) {
+            $parts = explode('/', $file);
+            $topDir = $parts[0];
+
+            if (! isset($knownDirs[$topDir])) {
+                $orphanedFiles[] = $file;
+            }
+        }
+
+        // 2. Find reverse orphans (Media records with missing primary file)
+        $reverseOrphans = [];
+
+        foreach ($mediaRecords as $media) {
+            if (! $filesystem->exists($media->getPath())) {
+                $reverseOrphans[] = $media;
+            }
+        }
+
+        $this->info("Disk: $diskName");
+        $this->info('Media records on this disk: '.$mediaRecords->count());
+        $this->newLine();
+
+        // Report orphaned files
+        $orphanedCount = count($orphanedFiles);
+
+        if ($orphanedCount === 0) {
+            $this->info('No orphaned files found.');
+        } else {
+            $this->warn("Found $orphanedCount orphaned file(s):");
+
+            foreach ($orphanedFiles as $file) {
+                $this->line("  <fg=red>FILE</> $file");
+            }
+
+            if (! $dryRun) {
+                $deleted = 0;
+
+                foreach ($orphanedFiles as $file) {
+                    $filesystem->delete($file);
+                    $deleted++;
+                }
+
+                $this->info("Deleted $deleted orphaned file(s).");
+            } else {
+                $this->comment('Run with --force to delete orphaned files.');
+            }
+        }
+
+        $this->newLine();
+
+        // Report reverse orphans
+        $reverseCount = count($reverseOrphans);
+
+        if ($reverseCount === 0) {
+            $this->info('No reverse orphans found (all records have their files on disk).');
+        } else {
+            $this->warn("Found $reverseCount record(s) with missing files:");
+
+            foreach ($reverseOrphans as $media) {
+                $this->line("  <fg=yellow>ID $media->id</> \"$media->name\" → {$media->getPath()}");
+            }
+
+            $this->comment('These records reference files that do not exist on disk.');
+            $this->comment('Review manually and delete the records if the files are truly lost.');
+        }
+
+        return 0;
+    }
+}

--- a/src/MediaManServiceProvider.php
+++ b/src/MediaManServiceProvider.php
@@ -4,6 +4,7 @@ namespace Emaia\MediaMan;
 
 use Emaia\MediaMan\Console\Commands\ClearResponsiveImagesCommand;
 use Emaia\MediaMan\Console\Commands\GenerateResponsiveImagesCommand;
+use Emaia\MediaMan\Console\Commands\MediamanCleanCommand;
 use Emaia\MediaMan\Console\Commands\MediamanPublishConfigCommand;
 use Emaia\MediaMan\Console\Commands\MediamanPublishMigrationCommand;
 use Emaia\MediaMan\Console\Commands\ResponsiveImagesStatsCommand;
@@ -58,6 +59,7 @@ class MediaManServiceProvider extends ServiceProvider
                 GenerateResponsiveImagesCommand::class,
                 ClearResponsiveImagesCommand::class,
                 ResponsiveImagesStatsCommand::class,
+                MediamanCleanCommand::class,
             ]);
         }
 

--- a/tests/Feature/Commands/MediamanCleanCommandTest.php
+++ b/tests/Feature/Commands/MediamanCleanCommandTest.php
@@ -1,0 +1,121 @@
+<?php
+
+use Emaia\MediaMan\MediaUploader;
+use Emaia\MediaMan\Models\Media;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+it('reports no orphans when everything is clean', function () {
+    $file = UploadedFile::fake()->image('photo.jpg');
+    MediaUploader::source($file)->upload();
+
+    $this->artisan('mediaman:clean')
+        ->expectsOutputToContain('Media records on this disk: 1')
+        ->expectsOutputToContain('No orphaned files found')
+        ->expectsOutputToContain('No reverse orphans found')
+        ->assertExitCode(0);
+});
+
+it('detects orphaned files on disk without a media record', function () {
+    Storage::fake('orphan-disk');
+    Storage::disk('orphan-disk')->put('orphan-dir/orphan.txt', 'orphan content');
+
+    $this->artisan('mediaman:clean', ['--disk' => 'orphan-disk'])
+        ->expectsOutputToContain('Found 1 orphaned file(s)')
+        ->expectsOutputToContain('orphan-dir/orphan.txt')
+        ->assertExitCode(0);
+});
+
+it('does not delete orphaned files in dry run mode', function () {
+    Storage::fake('dry-run-disk');
+    Storage::disk('dry-run-disk')->put('orphan/evil.php', 'bad content');
+
+    $this->artisan('mediaman:clean', ['--disk' => 'dry-run-disk'])
+        ->expectsOutputToContain('Run with --force to delete orphaned files.')
+        ->assertExitCode(0);
+
+    expect(Storage::disk('dry-run-disk')->exists('orphan/evil.php'))->toBeTrue();
+});
+
+it('deletes orphaned files with --force flag', function () {
+    Storage::fake('force-disk');
+    Storage::disk('force-disk')->put('orphan/evil.php', 'bad content');
+
+    $this->artisan('mediaman:clean', ['--disk' => 'force-disk', '--force' => true])
+        ->expectsOutputToContain('Deleted')
+        ->assertExitCode(0);
+
+    expect(Storage::disk('force-disk')->exists('orphan/evil.php'))->toBeFalse();
+});
+
+it('detects multiple orphaned files', function () {
+    Storage::fake('multi-orphan-disk');
+    Storage::disk('multi-orphan-disk')->put('a/file1.txt', 'x');
+    Storage::disk('multi-orphan-disk')->put('b/file2.txt', 'y');
+
+    $this->artisan('mediaman:clean', ['--disk' => 'multi-orphan-disk'])
+        ->expectsOutputToContain('Found 2 orphaned file(s)')
+        ->assertExitCode(0);
+});
+
+it('detects reverse orphans when media record has no file on disk', function () {
+    $media = new Media;
+    $media->name = 'lostfile';
+    $media->file_name = 'lost.jpg';
+    $media->disk = self::DEFAULT_DISK;
+    $media->mime_type = 'image/jpeg';
+    $media->size = 100;
+    $media->save();
+
+    $this->artisan('mediaman:clean')
+        ->expectsOutputToContain('Found 1 record(s) with missing files')
+        ->expectsOutputToContain('lostfile')
+        ->assertExitCode(0);
+});
+
+it('shows record count correctly', function () {
+    MediaUploader::source(UploadedFile::fake()->image('a.jpg'))->upload();
+    MediaUploader::source(UploadedFile::fake()->image('b.jpg'))->upload();
+
+    $this->artisan('mediaman:clean')
+        ->expectsOutputToContain('Media records on this disk: 2')
+        ->assertExitCode(0);
+});
+
+it('does not flag files within a valid media directory as orphans', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $this->artisan('mediaman:clean')
+        ->expectsOutputToContain('No orphaned files found')
+        ->expectsOutputToContain('No reverse orphans found')
+        ->assertExitCode(0);
+});
+
+it('preserves valid media files when --force is used', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    Storage::disk(self::DEFAULT_DISK)->put('orphan-dir/evil.txt', 'x');
+
+    $this->artisan('mediaman:clean', ['--force' => true])
+        ->assertExitCode(0);
+
+    expect(Storage::disk(self::DEFAULT_DISK)->exists($media->getPath()))->toBeTrue();
+    expect(Storage::disk(self::DEFAULT_DISK)->exists('orphan-dir/evil.txt'))->toBeFalse();
+});
+
+it('handles non-existent disk gracefully', function () {
+    $this->artisan('mediaman:clean', ['--disk' => 'nonexistent'])
+        ->expectsOutputToContain('not defined')
+        ->assertExitCode(1);
+});
+
+it('allows scanning a specific disk', function () {
+    Storage::fake('secondary');
+    Storage::disk('secondary')->put('orphan/other.txt', 'data');
+
+    $this->artisan('mediaman:clean', ['--disk' => 'secondary'])
+        ->expectsOutputToContain('Disk: secondary')
+        ->expectsOutputToContain('Media records on this disk: 0')
+        ->expectsOutputToContain('orphan/other.txt')
+        ->assertExitCode(0);
+});


### PR DESCRIPTION
## Summary

- New `mediaman:clean` artisan command
- Reports two kinds of orphans: files on disk without a Media record, and Media records whose file is missing
- Dry-run by default; `--force` deletes orphan files on disk
- DB records are never auto-deleted — reverse orphans are reported only, for manual review
- `--disk` option to scope to a specific filesystem
- Detection works at the top-level media directory level; stale conversion/responsive files within a valid media directory are not flagged (future scope)

## Test plan

- [x] `composer test` — 424/424 (1 skip env-dependent)
- [x] `composer analyse` — clean
- [ ] Manual smoke: drop a stray file in the media disk, run `mediaman:clean`, confirm reported
- [ ] Manual smoke: same with `--force`, confirm deleted
- [ ] Manual smoke: delete a media file from disk manually, run command, confirm reverse orphan reported
- [ ] Manual smoke: confirm valid media files are never touched by `--force`
- [ ] Manual smoke: `mediaman:clean --disk=nonexistent` exits 1 with clear message