### PR TITLE
Add multi-source uploads: fromDisk, fromBase64, fromUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,109 @@ retrieve a random file. More on customization will be added later.
 **Reminder: MediaMan treats any file (instance of `Illuminate\Http\UploadedFile`) as a media source. If you want a
 certain file type can be uploaded, you can use Laravel's validator.**
 
+### Upload from other sources
+
+Beyond `source($file)`, `MediaUploader` can ingest files from a Laravel disk, a base64-encoded payload, or a remote
+URL.
+
+#### From a Laravel disk
+
+```php
+$media = MediaUploader::fromDisk('uploads/photo.jpg', 'public')->upload();
+```
+
+The source file stays on the original disk; MediaMan copies it into the target disk through the standard upload
+pipeline. All fluent options (`useName`, `useCollection`, `useDisk`, `withCustomProperties`, etc.) still apply:
+
+```php
+$media = MediaUploader::fromDisk('imports/legacy.png', 'staging')
+            ->useCollection('Imports')
+            ->useDisk('media')
+            ->upload();
+```
+
+#### From a base64 string or data URI
+
+```php
+// Raw base64
+$media = MediaUploader::fromBase64(base64_encode($bytes), 'photo.jpg')->upload();
+
+// Data URI (e.g. produced by a browser canvas)
+$media = MediaUploader::fromBase64('data:image/png;base64,iVBORw0...', 'photo.png')->upload();
+
+// Optional custom display name (third argument)
+$media = MediaUploader::fromBase64($data, 'photo.png', 'User Avatar')->upload();
+```
+
+The raw payload size is checked **before** decoding to prevent memory blow-ups. Configure the limit in
+`config/mediaman.php`:
+
+```php
+'base64' => [
+    'max_size_bytes' => 50 * 1024 * 1024, // 50 MB default
+],
+```
+
+Payloads above the limit throw `Emaia\MediaMan\Exceptions\FileSizeExceeded` **before** any decode happens. Invalid
+base64 or a malformed data URI throws `Emaia\MediaMan\Exceptions\InvalidBase64Data`.
+
+#### From a remote URL
+
+```php
+$media = MediaUploader::fromUrl('https://example.com/photo.jpg')->upload();
+```
+
+`fromUrl` requires the **ext-curl** PHP extension (declared in `composer.json`).
+
+The URL passes through SSRF validation before any HTTP request leaves your server. By default, requests to
+private and reserved IPs (`10/8`, `127/8`, `169.254/16` AWS/GCP metadata, `172.16/12`, `192.168/16`, IPv6 ULA, etc.)
+are rejected with `Emaia\MediaMan\Exceptions\UrlNotAllowed`. The resolved IPs are then pinned via `CURLOPT_RESOLVE`
+so the actual download targets exactly what the guard validated — mitigating DNS rebinding.
+
+Configure in `config/mediaman.php`:
+
+```php
+'url_sources' => [
+    'allow_private_hosts' => false,             // opt out of SSRF protection
+    'timeout_seconds'     => 30,
+    'max_size_bytes'      => 100 * 1024 * 1024, // 100 MB
+    'verify_ssl'          => true,
+    'user_agent'          => 'MediaMan/2.x',
+],
+```
+
+Download safety runs in layers:
+
+1. **Scheme + host validation** — only `http`/`https`; private/loopback/metadata IPs rejected
+2. **HEAD `Content-Length` pre-check** — oversized files rejected before bytes are downloaded
+3. **In-stream size guard** — download aborts mid-stream if `max_size_bytes` is exceeded
+4. **Post-download filesize verification** — defense in depth
+
+#### Custom downloader
+
+`fromUrl` dispatches the download through the `Emaia\MediaMan\Downloaders\Downloader` interface, bound by default
+to `HttpDownloader` (Laravel HTTP client). Swap it in a service provider to use a different HTTP stack, add
+retries, or instrument logging:
+
+```php
+use Emaia\MediaMan\Downloaders\Downloader;
+
+$this->app->bind(Downloader::class, MyCustomDownloader::class);
+```
+
+In tests, mock the interface to avoid real network calls:
+
+```php
+$mock = Mockery::mock(Downloader::class);
+$mock->shouldReceive('download')->andReturn([
+    'path' => $tmpPath,
+    'mime' => 'image/jpeg',
+    'size' => 12345,
+]);
+
+app()->instance(Downloader::class, $mock);
+```
+
 ### Retrieve media
 
 You can use any Eloquent operation to retrieve a media, plus we've added findByName().

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "illuminate/support": "^12.0|^13.0",
         "illuminate/database": "^12.0|^13.0",
         "illuminate/validation": "^12.0|^13.0",
-        "intervention/image": "^4.0"
+        "intervention/image": "^4.0",
+        "ext-curl": "*"
     },
     "require-dev": {
         "larastan/larastan": "^3.0",

--- a/config/mediaman.php
+++ b/config/mediaman.php
@@ -167,6 +167,32 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Base64 Upload Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Settings for uploading files from base64-encoded data (fromBase64).
+    |
+    */
+
+    'base64' => [
+
+        /*
+        |--------------------------------------------------------------------------
+        | Maximum Payload Size (bytes)
+        |--------------------------------------------------------------------------
+        |
+        | Maximum size of the raw base64 string before decoding.
+        | The check runs before any memory-intensive decode operation.
+        | Default is 50 MB.
+        |
+        */
+
+        'max_size_bytes' => 50 * 1024 * 1024,
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | The queue that should be used to perform image conversions
     |--------------------------------------------------------------------------
     |

--- a/src/Downloaders/Downloader.php
+++ b/src/Downloaders/Downloader.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Emaia\MediaMan\Downloaders;
+
+interface Downloader
+{
+    /**
+     * Download a file from a URL to a local path.
+     *
+     * @param  array{host: string, port: int, ips: string[]}|null  $resolved
+     * @return array{path: string, mime: string, size: int}
+     */
+    public function download(string $url, string $destinationPath, ?array $resolved = null): array;
+}

--- a/src/Downloaders/HttpDownloader.php
+++ b/src/Downloaders/HttpDownloader.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Emaia\MediaMan\Downloaders;
+
+use Emaia\MediaMan\Exceptions\FileSizeExceeded;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+class HttpDownloader implements Downloader
+{
+    public function download(string $url, string $destinationPath, ?array $resolved = null): array
+    {
+        $timeout = (int) config('mediaman.url_sources.timeout_seconds', 30);
+        $maxSize = (int) config('mediaman.url_sources.max_size_bytes', 100 * 1024 * 1024);
+        $verifySsl = config('mediaman.url_sources.verify_ssl', true);
+        $userAgent = config('mediaman.url_sources.user_agent', 'MediaMan/2.x');
+
+        $this->checkContentLength($url, $maxSize, $timeout, $verifySsl, $userAgent);
+
+        $curlOptions = [];
+
+        if ($resolved !== null && ! empty($resolved['ips'])) {
+            $curlOptions[\CURLOPT_RESOLVE] = array_map(
+                fn (string $ip): string => "{$resolved['host']}:{$resolved['port']}:$ip",
+                $resolved['ips']
+            );
+        }
+
+        try {
+            $response = Http::timeout($timeout)
+                ->withOptions(['verify' => $verifySsl])
+                ->withHeaders(['User-Agent' => $userAgent])
+                ->withOptions([
+                    'curl' => $curlOptions,
+                    'sink' => $destinationPath,
+                    'progress' => function (int $downloadTotal, int $downloadedBytes) use ($maxSize) {
+                        if ($downloadedBytes > $maxSize) {
+                            throw new RuntimeException('Download exceeds maximum allowed size.');
+                        }
+                    },
+                ])
+                ->get($url);
+        } catch (ConnectionException $e) {
+            throw new RuntimeException("Failed to connect to URL: {$e->getMessage()}", 0, $e);
+        }
+
+        if (! $response->successful()) {
+            @unlink($destinationPath);
+
+            throw new RuntimeException("Download failed with HTTP status {$response->status()}.");
+        }
+
+        /** @var string $mime */
+        $mime = $response->header('Content-Type') ?: 'application/octet-stream';
+        $mime = strtok($mime, ';') ?: 'application/octet-stream';
+
+        $size = filesize($destinationPath);
+
+        if ($size > $maxSize) {
+            @unlink($destinationPath);
+
+            throw FileSizeExceeded::forSize($size, $maxSize);
+        }
+
+        return [
+            'path' => $destinationPath,
+            'mime' => $mime,
+            'size' => $size,
+        ];
+    }
+
+    private function checkContentLength(
+        string $url,
+        int $maxSize,
+        int $timeout,
+        bool $verifySsl,
+        string $userAgent,
+    ): void {
+        try {
+            $response = Http::timeout($timeout)
+                ->withOptions(['verify' => $verifySsl])
+                ->withHeaders(['User-Agent' => $userAgent])
+                ->head($url);
+
+            if (! $response->successful()) {
+                return;
+            }
+
+            /** @var string|null $contentLength */
+            $contentLength = $response->header('Content-Length');
+
+            if ($contentLength === null || $contentLength === '') {
+                return;
+            }
+
+            if ((int) $contentLength > $maxSize) {
+                throw FileSizeExceeded::forSize((int) $contentLength, $maxSize);
+            }
+        } catch (ConnectionException) {
+            // HEAD request failed, proceed to download anyway
+        }
+    }
+}

--- a/src/Exceptions/InvalidBase64Data.php
+++ b/src/Exceptions/InvalidBase64Data.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Emaia\MediaMan\Exceptions;
+
+use Exception;
+
+class InvalidBase64Data extends Exception
+{
+    public static function invalid(): self
+    {
+        return new self('Invalid base64 data.');
+    }
+
+    public static function invalidDataUri(): self
+    {
+        return new self('Invalid data URI format.');
+    }
+}

--- a/src/MediaManServiceProvider.php
+++ b/src/MediaManServiceProvider.php
@@ -8,6 +8,8 @@ use Emaia\MediaMan\Console\Commands\MediamanCleanCommand;
 use Emaia\MediaMan\Console\Commands\MediamanPublishConfigCommand;
 use Emaia\MediaMan\Console\Commands\MediamanPublishMigrationCommand;
 use Emaia\MediaMan\Console\Commands\ResponsiveImagesStatsCommand;
+use Emaia\MediaMan\Downloaders\Downloader;
+use Emaia\MediaMan\Downloaders\HttpDownloader;
 use Emaia\MediaMan\ResponsiveImages\ResponsiveConversions;
 use Emaia\MediaMan\ResponsiveImages\ResponsiveImageGenerator;
 use Emaia\MediaMan\ResponsiveImages\WidthCalculator\BreakpointWidthCalculator;
@@ -32,6 +34,8 @@ class MediaManServiceProvider extends ServiceProvider
         );
 
         $this->app->singleton(ConversionRegistry::class);
+
+        $this->app->bind(Downloader::class, HttpDownloader::class);
 
         $this->registerImageManager();
         $this->registerResponsiveImageServices();

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -2,14 +2,19 @@
 
 namespace Emaia\MediaMan;
 
+use Emaia\MediaMan\Downloaders\Downloader;
+use Emaia\MediaMan\Enums\MediaFormat;
 use Emaia\MediaMan\Enums\MediaType;
 use Emaia\MediaMan\Events\MediaUploaded;
 use Emaia\MediaMan\Exceptions\DisallowedExtension;
 use Emaia\MediaMan\Exceptions\FileSizeExceeded;
+use Emaia\MediaMan\Exceptions\InvalidBase64Data;
 use Emaia\MediaMan\Exceptions\MimeTypeNotAllowed;
 use Emaia\MediaMan\Models\Media;
+use Emaia\MediaMan\Support\UrlGuard;
 use Emaia\MediaMan\Traits\ResolvesModels;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 
 class MediaUploader
 {
@@ -55,6 +60,205 @@ class MediaUploader
     public static function source(UploadedFile $file): MediaUploader
     {
         return new self($file);
+    }
+
+    /**
+     * Create an uploader from a file on an existing filesystem disk.
+     *
+     * TODO: use readStream/writeStream to avoid loading the entire file
+     * into memory at once (relevant for very large files on cloud disks).
+     */
+    public static function fromDisk(string $path, string $disk): MediaUploader
+    {
+        $filesystem = Storage::disk($disk);
+
+        if (! $filesystem->exists($path)) {
+            throw new \RuntimeException("File [{$path}] not found on disk [{$disk}].");
+        }
+
+        $tmpPath = tempnam(sys_get_temp_dir(), 'mediaman_');
+
+        try {
+            file_put_contents($tmpPath, $filesystem->get($path));
+
+            $uploadedFile = new UploadedFile(
+                $tmpPath,
+                basename($path),
+                $filesystem->mimeType($path),
+                null,
+                true
+            );
+
+            return new self($uploadedFile);
+        } catch (\Throwable $e) {
+            @unlink($tmpPath);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Create an uploader from a base64-encoded string.
+     */
+    public static function fromBase64(string $data, string $filename, ?string $name = null): MediaUploader
+    {
+        $maxBytes = (int) config('mediaman.base64.max_size_bytes', 50 * 1024 * 1024);
+
+        if ($maxBytes > 0 && strlen($data) > $maxBytes) {
+            throw FileSizeExceeded::forSize(strlen($data), $maxBytes);
+        }
+
+        if (str_starts_with($data, 'data:')) {
+            $commaPos = strpos($data, ',');
+
+            if ($commaPos === false) {
+                throw InvalidBase64Data::invalidDataUri();
+            }
+
+            $data = substr($data, $commaPos + 1);
+        }
+
+        $decoded = base64_decode($data, true);
+
+        if ($decoded === false) {
+            throw InvalidBase64Data::invalid();
+        }
+
+        $tmpPath = tempnam(sys_get_temp_dir(), 'mediaman_');
+
+        try {
+            file_put_contents($tmpPath, $decoded);
+
+            $fileInfo = finfo_open(FILEINFO_MIME_TYPE);
+            $mimeType = finfo_file($fileInfo, $tmpPath);
+            finfo_close($fileInfo);
+
+            $mimeType = $mimeType !== false ? $mimeType : 'application/octet-stream';
+
+            $uploadedFile = new UploadedFile(
+                $tmpPath,
+                $filename,
+                $mimeType,
+                null,
+                true
+            );
+
+            $instance = new self($uploadedFile);
+
+            if ($name !== null) {
+                $instance->setName($name);
+            }
+
+            return $instance;
+        } catch (\Throwable $e) {
+            @unlink($tmpPath);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Create an uploader from a remote URL.
+     */
+    public static function fromUrl(string $url): MediaUploader
+    {
+        $resolved = UrlGuard::resolve($url);
+
+        // Defensive normalization: rebuild the URL with the lowercased host so
+        // curl's CURLOPT_RESOLVE entries (also lowercased) match unambiguously.
+        $downloadUrl = self::normalizeUrlHost($url, $resolved['host']);
+
+        $tmpPath = tempnam(sys_get_temp_dir(), 'mediaman_');
+
+        try {
+            $downloader = app(Downloader::class);
+            $result = $downloader->download($downloadUrl, $tmpPath, $resolved);
+
+            $suggestedName = basename(parse_url($url, PHP_URL_PATH) ?: '');
+
+            if ($suggestedName === '') {
+                $suggestedName = 'download';
+            }
+
+            if (pathinfo($suggestedName, PATHINFO_EXTENSION) === '') {
+                $ext = self::extensionForMime($result['mime']);
+
+                if ($ext !== '') {
+                    $suggestedName .= '.'.$ext;
+                }
+            }
+
+            $uploadedFile = new UploadedFile(
+                $tmpPath,
+                $suggestedName,
+                $result['mime'],
+                null,
+                true
+            );
+
+            return new self($uploadedFile);
+        } catch (\Throwable $e) {
+            @unlink($tmpPath);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Pick a file extension for a MIME type. Uses the format map for images
+     * (authoritative) and falls back to the MIME subtype for other types.
+     */
+    private static function extensionForMime(string $mimeType): string
+    {
+        if (str_starts_with($mimeType, 'image/')) {
+            return MediaFormat::extensionFromMimeType($mimeType);
+        }
+
+        $slash = strrpos($mimeType, '/');
+
+        return $slash !== false ? substr($mimeType, $slash + 1) : '';
+    }
+
+    /**
+     * Rebuild a URL with a lowercased host component, preserving the rest.
+     */
+    private static function normalizeUrlHost(string $url, string $lowercaseHost): string
+    {
+        $parts = parse_url($url);
+
+        if (! is_array($parts) || ! isset($parts['host']) || $parts['host'] === $lowercaseHost) {
+            return $url;
+        }
+
+        $rebuilt = ($parts['scheme'] ?? 'http').'://';
+
+        if (isset($parts['user'])) {
+            $rebuilt .= $parts['user'];
+
+            if (isset($parts['pass'])) {
+                $rebuilt .= ':'.$parts['pass'];
+            }
+
+            $rebuilt .= '@';
+        }
+
+        $rebuilt .= $lowercaseHost;
+
+        if (isset($parts['port'])) {
+            $rebuilt .= ':'.$parts['port'];
+        }
+
+        $rebuilt .= $parts['path'] ?? '';
+
+        if (isset($parts['query'])) {
+            $rebuilt .= '?'.$parts['query'];
+        }
+
+        if (isset($parts['fragment'])) {
+            $rebuilt .= '#'.$parts['fragment'];
+        }
+
+        return $rebuilt;
     }
 
     /**

--- a/src/Support/UrlGuard.php
+++ b/src/Support/UrlGuard.php
@@ -25,6 +25,47 @@ class UrlGuard
 
     public static function check(string $url): void
     {
+        self::parseAndValidate($url);
+    }
+
+    /**
+     * Validate a URL and return the resolved IP addresses.
+     *
+     * Use this instead of check() when you need to pin the resolved
+     * IPs in a subsequent HTTP request to prevent DNS rebinding.
+     *
+     * @return array{host: string, port: int, ips: string[]}
+     */
+    public static function resolve(string $url): array
+    {
+        $parts = self::parseAndValidate($url);
+
+        $host = strtolower($parts['host']);
+        $port = isset($parts['port'])
+            ? (int) $parts['port']
+            : (strtolower($parts['scheme']) === 'https' ? 443 : 80);
+
+        $ips = [];
+
+        // allow_private_hosts=true means the user has opted out of SSRF
+        // protection; returning an empty ips array skips CURLOPT_RESOLVE
+        // pinning downstream and lets curl resolve freely.
+        if (! config('mediaman.url_sources.allow_private_hosts', false)) {
+            $ips = self::resolveHost($host);
+        }
+
+        return [
+            'host' => $host,
+            'port' => $port,
+            'ips' => $ips,
+        ];
+    }
+
+    /**
+     * @return array{scheme?: string, host: string, port?: int}
+     */
+    private static function parseAndValidate(string $url): array
+    {
         $parts = @parse_url($url);
 
         if ($parts === false || ! isset($parts['host'])) {
@@ -44,6 +85,8 @@ class UrlGuard
         }
 
         self::checkHost($host);
+
+        return $parts;
     }
 
     private static function checkHost(string $host): void
@@ -169,9 +212,6 @@ class UrlGuard
 
     /**
      * @return string[]
-     *
-     * TODO(2.4): pin resolved IPs in HttpDownloader via CURLOPT_RESOLVE
-     * to prevent DNS rebinding between this check and the actual fetch.
      */
     private static function resolveHost(string $host): array
     {

--- a/tests/Feature/MultiSourceUploadTest.php
+++ b/tests/Feature/MultiSourceUploadTest.php
@@ -1,0 +1,217 @@
+<?php
+
+use Emaia\MediaMan\Downloaders\Downloader;
+use Emaia\MediaMan\Exceptions\FileSizeExceeded;
+use Emaia\MediaMan\Exceptions\InvalidBase64Data;
+use Emaia\MediaMan\Exceptions\UrlNotAllowed;
+use Emaia\MediaMan\MediaUploader;
+use Emaia\MediaMan\Models\Media;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+function fakeTmpFile(string $content = 'hello world'): string
+{
+    $path = tempnam(sys_get_temp_dir(), 'mediaman_test_');
+    file_put_contents($path, $content);
+
+    return $path;
+}
+
+// --- fromDisk ---
+
+it('can upload from a file on another disk', function () {
+    Storage::fake('source-disk');
+    Storage::disk('source-disk')->put('photos/image.jpg', 'fake image content');
+
+    $media = MediaUploader::fromDisk('photos/image.jpg', 'source-disk')->upload();
+
+    expect($media)->toBeInstanceOf(Media::class)
+        ->and($media->file_name)->toEqual('image.jpg')
+        ->and($media->disk)->toEqual(self::DEFAULT_DISK);
+
+    expect(Storage::disk(self::DEFAULT_DISK)->exists($media->getPath()))->toBeTrue();
+});
+
+it('fromDisk preserves the source file on the original disk', function () {
+    Storage::fake('source-disk');
+    Storage::disk('source-disk')->put('photos/image.jpg', 'original content');
+
+    MediaUploader::fromDisk('photos/image.jpg', 'source-disk')->upload();
+
+    expect(Storage::disk('source-disk')->exists('photos/image.jpg'))->toBeTrue();
+});
+
+it('fromDisk throws when the file does not exist on the source disk', function () {
+    Storage::fake('source-disk');
+
+    MediaUploader::fromDisk('missing/file.jpg', 'source-disk');
+})->throws(RuntimeException::class, 'not found');
+
+// --- fromBase64 ---
+
+it('can upload from a base64 string', function () {
+    $b64 = base64_encode('hello world');
+
+    $media = MediaUploader::fromBase64($b64, 'hello.txt')->upload();
+
+    expect($media)->toBeInstanceOf(Media::class)
+        ->and($media->file_name)->toEndWith('.txt');
+});
+
+it('can upload from a data URI', function () {
+    $dataUri = 'data:text/plain;base64,'.base64_encode('hello world');
+
+    $media = MediaUploader::fromBase64($dataUri, 'hello.txt')->upload();
+
+    expect($media)->toBeInstanceOf(Media::class);
+});
+
+it('can set a custom name from base64', function () {
+    $b64 = base64_encode('hello');
+
+    $media = MediaUploader::fromBase64($b64, 'hello.txt', 'My Custom Name')->upload();
+
+    expect($media->name)->toEqual('My Custom Name');
+});
+
+it('rejects base64 when payload exceeds max_size_bytes', function () {
+    Config::set('mediaman.base64.max_size_bytes', 100);
+
+    $bigData = str_repeat('A', 200);
+
+    MediaUploader::fromBase64($bigData, 'big.txt');
+})->throws(FileSizeExceeded::class);
+
+it('allows base64 within size limit', function () {
+    Config::set('mediaman.base64.max_size_bytes', 50 * 1024 * 1024);
+
+    $b64 = base64_encode('hello');
+
+    $media = MediaUploader::fromBase64($b64, 'hello.txt')->upload();
+
+    expect($media)->toBeInstanceOf(Media::class);
+});
+
+it('rejects invalid base64 data', function () {
+    MediaUploader::fromBase64('not-valid-base64!!!', 'file.txt');
+})->throws(InvalidBase64Data::class, 'Invalid base64');
+
+it('rejects data URI with no comma', function () {
+    MediaUploader::fromBase64('data:image/png;base64', 'file.png');
+})->throws(InvalidBase64Data::class, 'Invalid data URI');
+
+// --- fromUrl ---
+
+it('validates URLs through UrlGuard', function () {
+    MediaUploader::fromUrl('http://127.0.0.1/file.jpg');
+})->throws(UrlNotAllowed::class);
+
+it('downloads from a URL via the Downloader', function () {
+    $tmpPath = fakeTmpFile('fake image content');
+
+    $downloader = Mockery::mock(Downloader::class);
+    $downloader->shouldReceive('download')
+        ->once()
+        ->with('https://example.com/photo.jpg', Mockery::any(), Mockery::any())
+        ->andReturn([
+            'path' => $tmpPath,
+            'mime' => 'image/jpeg',
+            'size' => strlen('fake image content'),
+        ]);
+
+    app()->instance(Downloader::class, $downloader);
+
+    $media = MediaUploader::fromUrl('https://example.com/photo.jpg')->upload();
+
+    expect($media)->toBeInstanceOf(Media::class)
+        ->and($media->file_name)->toEqual('photo.jpg');
+});
+
+it('preserves URL filename when downloading', function () {
+    $tmpPath = fakeTmpFile('pdf content');
+
+    $downloader = Mockery::mock(Downloader::class);
+    $downloader->shouldReceive('download')
+        ->andReturn([
+            'path' => $tmpPath,
+            'mime' => 'application/pdf',
+            'size' => 11,
+        ]);
+
+    app()->instance(Downloader::class, $downloader);
+
+    $media = MediaUploader::fromUrl('https://example.com/assets/report.pdf')->upload();
+
+    expect($media->file_name)->toEqual('report.pdf');
+});
+
+it('derives extension from MIME when URL path is a bare domain', function () {
+    $tmpPath = fakeTmpFile('png content');
+
+    $downloader = Mockery::mock(Downloader::class);
+    $downloader->shouldReceive('download')
+        ->andReturn([
+            'path' => $tmpPath,
+            'mime' => 'image/png',
+            'size' => 11,
+        ]);
+
+    app()->instance(Downloader::class, $downloader);
+
+    $media = MediaUploader::fromUrl('https://example.com/')->upload();
+
+    expect($media->file_name)->toEqual('download.png');
+});
+
+it('passes resolved host/port/ips to the downloader', function () {
+    $tmpPath = fakeTmpFile('jpg content');
+
+    $downloader = Mockery::mock(Downloader::class);
+    $downloader->shouldReceive('download')
+        ->once()
+        ->withArgs(function (string $url, string $path, ?array $resolved) {
+            return $resolved !== null
+                && $resolved['host'] === 'example.com'
+                && $resolved['port'] === 443
+                && is_array($resolved['ips']);
+        })
+        ->andReturn(['path' => $tmpPath, 'mime' => 'image/jpeg', 'size' => 11]);
+
+    app()->instance(Downloader::class, $downloader);
+
+    MediaUploader::fromUrl('https://example.com/photo.jpg')->upload();
+});
+
+it('lowercases the URL host before passing to the downloader', function () {
+    $tmpPath = fakeTmpFile('jpg content');
+
+    $downloader = Mockery::mock(Downloader::class);
+    $downloader->shouldReceive('download')
+        ->once()
+        ->withArgs(function (string $url, string $path, ?array $resolved) {
+            return str_contains($url, 'example.com')
+                && ! str_contains($url, 'EXAMPLE.COM')
+                && $resolved['host'] === 'example.com';
+        })
+        ->andReturn(['path' => $tmpPath, 'mime' => 'image/jpeg', 'size' => 11]);
+
+    app()->instance(Downloader::class, $downloader);
+
+    MediaUploader::fromUrl('https://EXAMPLE.COM/photo.jpg')->upload();
+});
+
+it('rejects oversized files via HEAD Content-Length pre-check', function () {
+    // Artificially small limit so the HEAD Content-Length triggers
+    Config::set('mediaman.url_sources.max_size_bytes', 100);
+
+    Http::fake([
+        'https://example.com/huge.zip' => Http::response(null, 200, [
+            'Content-Length' => '999999999',
+        ]),
+    ]);
+
+    $downloader = app(Downloader::class);
+
+    $downloader->download('https://example.com/huge.zip', fakeTmpFile());
+})->throws(FileSizeExceeded::class);


### PR DESCRIPTION
## Summary

- `MediaUploader::fromDisk(path, disk)` — import from any Laravel filesystem disk; source file preserved on the original disk
- `MediaUploader::fromBase64(data, filename, ?name)` — decode and upload; pre-decode size guard via `base64.max_size_bytes` (default 50 MB); accepts both raw base64 and data URIs
- `MediaUploader::fromUrl(url)` — validates via `UrlGuard::resolve()`, downloads via the `Downloader` interface
- `Downloader` interface + `HttpDownloader` (Laravel HTTP client), bindable in the container for testing
- **DNS rebinding mitigation**: `UrlGuard::resolve()` returns `host`/`port`/`ips`; `HttpDownloader` pins the resolved IPs via `CURLOPT_RESOLVE` so the URL's host always resolves to what the guard validated
- URL host is lowercased before being passed to the downloader so `CURLOPT_RESOLVE` entries match unambiguously
- Filename for `fromUrl` falls back to a MIME-derived extension when the URL path has no usable name
- HEAD `Content-Length` pre-check; in-stream size guard via Guzzle `progress` callback; post-download filesize check
- `InvalidBase64Data` exception for malformed payloads
- Tmpfile cleanup on exception via try/catch with `unlink`

## Test plan

- [x] `composer test` — 441/441 (1 skip env-dependent)
- [x] `composer analyse` — clean
- [x] Manual smoke: `fromDisk('uploads/foo.jpg', 'public')` in a real Laravel app → record + file on media disk; source file untouched on `public`
- [x] Manual smoke: `fromBase64(base64_encode(file_get_contents($path)), 'img.png')` → valid media
- [x] Manual smoke: `fromBase64()` over `max_size_bytes` → `FileSizeExceeded` before decode
- [x] Manual smoke: `fromUrl('https://picsum.photos/800')` → downloaded and stored
- [x] Manual smoke: `fromUrl('http://169.254.169.254/')` → `UrlNotAllowed` (SSRF guard)
- [x] Manual smoke: serve a URL with `Content-Length` > limit → rejected via HEAD pre-check before download
- [x] Manual smoke: `fromUrl('https://EXAMPLE.COM/file.jpg')` against a real server → confirms `CURLOPT_RESOLVE` actually pins the IP curl uses