### PR TITLE
Add HTTP responses, mailAttachment, temporaryUrl, getLast* helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,17 @@ There are a few key concepts that need to be understood before continuing:
 * [Installation](#installation)
 * [Configuration](#configuration)
 * [Media](#media)
+  * [Upload media](#upload-media)
+  * [Upload from other sources](#upload-from-other-sources)
+  * [HTTP responses & mail](#http-responses--mail)
+  * [Custom Properties](#custom-properties)
 * [Media & Models](#media--models)
+  * [getFirst* / getLast* helpers](#retrieve-media-of-a-model)
 * [Collections](#collections)
 * [Media & Collections](#media--collections)
 * [Media, Models & Conversions](#conversions)
 * [Responsive Images](#responsive-images)
+* [Security](#security)
 * [Events](#events)
 * [Artisan Commands](#artisan-commands)
 * [Contribution and License](#contribution-and-license)
@@ -159,6 +165,27 @@ PHP image library to use via the `driver` config key:
 | `gd`      | ext-gd        | Lighter, bundled in most PHP installations        |
 
 If an invalid value is set, an `InvalidArgumentException` will be thrown at runtime.
+
+### Allowed MIME types and file size
+
+```php
+// file: config/mediaman.php
+'allowed_mime_types' => ['image/jpeg', 'image/png', 'application/pdf'],  // empty = allow all
+'max_file_size' => 10 * 1024 * 1024,  // 10 MB; 0 = unlimited
+```
+
+### Disallowed extensions and temporary URLs
+
+```php
+// Block dangerous file extensions on upload (default: true)
+'block_disallowed_extensions' => true,
+'disallowed_extensions' => ['php', 'phtml', 'phar', 'shtml', 'htaccess', 'cgi', 'pl', 'asp', 'aspx', 'jsp', 'jspx'],
+
+// Temporary URL lifetime for cloud disks (minutes)
+'temporary_url' => [
+    'default_lifetime_minutes' => 5,
+],
+```
 
 ### Custom Models
 
@@ -495,6 +522,69 @@ $media->getPath('conversion-name')
 $media->getDirectory()
 ```
 
+### HTTP responses & mail
+
+Media models can generate ready-to-use HTTP responses, stream resources, and mail attachments:
+
+```php
+// StreamedResponse with Content-Disposition: attachment
+return $media->toResponse();
+
+// StreamedResponse for inline browser display
+return $media->toInlineResponse();
+
+// Raw stream resource (for custom handling)
+$stream = $media->getStream();
+```
+
+All three accept an optional `$conversion` name to serve a specific conversion instead of the original:
+
+```php
+return $media->toResponse('thumb');
+return $media->toInlineResponse('thumb');
+$stream = $media->getStream('thumb');
+```
+
+#### Temporary URLs (S3 / cloud disks)
+
+Generate a signed, time-limited URL for cloud disks that support it:
+
+```php
+use Emaia\MediaMan\Exceptions\TemporaryUrlNotSupported;
+
+try {
+    $url = $media->getTemporaryUrl(now()->addHour(), 'thumb');
+} catch (TemporaryUrlNotSupported $e) {
+    // local disk — fall back to a controller route
+}
+```
+
+The `$expiration` parameter defaults to `temporary_url.default_lifetime_minutes` (5 min) from the config when omitted.
+
+#### Mail attachments
+
+Media implements `Illuminate\Contracts\Mail\Attachable`, so you can pass a Media instance directly to a Mailable:
+
+```php
+use Illuminate\Mail\Mailable;
+
+class WelcomeMail extends Mailable
+{
+    public function build()
+    {
+        return $this->view('emails.welcome')
+                    ->attach(Media::find(1));
+    }
+}
+```
+
+For inline usage or explicit conversion selection, use `mailAttachment()`:
+
+```php
+$attachment = $media->mailAttachment();           // original
+$attachment = $media->mailAttachment('thumb');     // specific conversion
+```
+
 ### Custom Properties
 
 You can store arbitrary metadata alongside any media item using custom properties.
@@ -714,6 +804,37 @@ $post->hasMediaConversion('featured-image', 'thumb'); // bool
 ```
 
 *Tip:* `getFirstMediaUrl()` accepts two optional arguments: channel name & conversion name.
+
+### getLastMedia helpers
+
+Mirroring `getFirst*`, MediaMan provides a complete set of `getLast*` methods for retrieving the most recently
+attached media:
+
+```php
+// Last media item from the default channel
+$post->getLastMedia();
+
+// Last media item from the specified channel
+$post->getLastMedia('featured-image');
+
+// URL of the last media item from the default channel
+$post->getLastMediaUrl();
+
+// URL of the last media item from the specified channel
+$post->getLastMediaUrl('featured-image');
+
+// URL of a conversion of the last media item (returns '' if not found)
+$post->getLastMediaUrl('featured-image', 'thumb');
+
+// URL with fallback to original if the conversion doesn't exist
+$post->getLastMediaUrlWithFallback('featured-image', 'thumb');
+
+// URL only if the conversion exists, otherwise null
+$post->getLastMediaConversionUrl('featured-image', 'thumb');
+
+// Whether the last media item has a specific conversion
+$post->hasLastMediaConversion('featured-image', 'thumb'); // bool
+```
 
 ### Disassociate media
 
@@ -1096,6 +1217,61 @@ This removes all variant files from storage and clears the metadata from `custom
 
 -----
 
+## Security
+
+### Disallowed file extensions
+
+MediaMan blocks executable and server-side file extensions by default to prevent malicious file uploads.
+The blocklist includes: `php`, `phtml`, `phar`, `shtml`, `htaccess`, `cgi`, `pl`, `asp`, `aspx`, `jsp`, `jspx`.
+
+Configure or disable in `config/mediaman.php`:
+
+```php
+'block_disallowed_extensions' => true,   // set to false to opt out
+'disallowed_extensions' => [
+    'php', 'phtml', 'phar', 'shtml', 'htaccess',
+    'cgi', 'pl', 'asp', 'aspx', 'jsp', 'jspx',
+],
+```
+
+Uploads with a disallowed extension throw `Emaia\MediaMan\Exceptions\DisallowedExtension`.
+The check runs against the **sanitized** filename, so double-extension attacks (`malware.php.jpg`)
+are defused before the validator runs (the dot is replaced: `malware-php.jpg` → extension is `jpg`).
+
+### SSRF protection for remote URLs
+
+`fromUrl()` validates every URL through `Emaia\MediaMan\Support\UrlGuard` before downloading:
+
+- **Schemes**: only `http` and `https` are allowed
+- **Hostnames**: `localhost` and `*.localhost` are rejected
+- **IPv4**: `0/8`, `10/8`, `127/8`, `169.254/16` (AWS/GCP metadata), `172.16/12`, `192.168/16`, `255.255.255.255`
+- **IPv6**: `::/128` (unspecified), `::1` (loopback), `fc00::/7` (ULA), `fe80::/10` (link-local), `::ffff:x.x.x.x` (IPv4-mapped), `2002::/16` (6to4), `2001::/32` (Teredo)
+- **DNS**: both A and AAAA records are resolved; if **any** resolved IP is private, the URL is rejected
+
+To allow downloads from internal networks, set `url_sources.allow_private_hosts` to `true`.
+
+### `mediaman:clean` — detect orphaned files
+
+```bash
+# Dry run (default) — reports without deleting
+php artisan mediaman:clean
+
+# Delete orphaned files (DB records are never auto-deleted)
+php artisan mediaman:clean --force
+
+# Scan a specific disk
+php artisan mediaman:clean --disk=s3-media
+```
+
+The command finds:
+- **Orphaned files**: files on disk whose directory does not match any Media record
+- **Reverse orphans**: Media records whose primary file is missing from disk
+
+Reverse orphans are only reported — their DB records are never auto-deleted to prevent accidental cascade
+loss (a record may belong to multiple collections or channels).
+
+-----
+
 ## Events
 
 MediaMan dispatches events at key points in the media lifecycle, allowing you to hook into the process with standard
@@ -1202,6 +1378,24 @@ php artisan mediaman:responsive-stats
 
 Output includes: total image count, images with variants, coverage percentage, and the active configuration (quality,
 formats, breakpoints, enabled status).
+
+### Clean orphaned files
+
+Detect and remove files on disk that no longer have a corresponding Media record:
+
+```bash
+# Dry run (default) — reports without deleting
+php artisan mediaman:clean
+
+# Delete orphaned files
+php artisan mediaman:clean --force
+
+# Scan a specific disk
+php artisan mediaman:clean --disk=media
+```
+
+Also detects reverse orphans (Media records whose file is missing from disk) and reports them
+for manual review — DB records are never auto-deleted.
 
 -----
 

--- a/config/mediaman.php
+++ b/config/mediaman.php
@@ -193,6 +193,31 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Temporary URL Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Settings for generating temporary signed URLs for cloud disks.
+    |
+    */
+
+    'temporary_url' => [
+
+        /*
+        |--------------------------------------------------------------------------
+        | Default Lifetime (minutes)
+        |--------------------------------------------------------------------------
+        |
+        | The default expiration time for temporary URLs when no explicit
+        | expiration is provided. Default is 5 minutes.
+        |
+        */
+
+        'default_lifetime_minutes' => 5,
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | The queue that should be used to perform image conversions
     |--------------------------------------------------------------------------
     |

--- a/src/Exceptions/TemporaryUrlNotSupported.php
+++ b/src/Exceptions/TemporaryUrlNotSupported.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Emaia\MediaMan\Exceptions;
+
+use Exception;
+
+class TemporaryUrlNotSupported extends Exception
+{
+    public static function forDisk(string $disk): self
+    {
+        return new self("Disk [{$disk}] does not support temporary URLs.");
+    }
+}

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -2,26 +2,31 @@
 
 namespace Emaia\MediaMan\Models;
 
+use DateTimeInterface;
 use Emaia\MediaMan\Casts\Json;
 use Emaia\MediaMan\ConversionRegistry;
 use Emaia\MediaMan\Database\Factories\MediaFactory;
 use Emaia\MediaMan\Enums\MediaFormat;
 use Emaia\MediaMan\Enums\MediaType;
 use Emaia\MediaMan\Events\MediaDeleted;
+use Emaia\MediaMan\Exceptions\TemporaryUrlNotSupported;
 use Emaia\MediaMan\Traits\ResolvesModels;
 use Emaia\MediaMan\Traits\ResponsiveImages;
 use Exception;
 use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Contracts\Mail\Attachable;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Mail\Attachment;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
  * @property int $id
@@ -33,7 +38,7 @@ use InvalidArgumentException;
  * @property float|int $size
  * @property array $custom_properties
  */
-class Media extends Model
+class Media extends Model implements Attachable
 {
     use HasFactory, ResolvesModels, ResponsiveImages;
 
@@ -652,6 +657,83 @@ class Media extends Model
         $this->custom_properties = $customProperties;
 
         return $this;
+    }
+
+    /**
+     * Stream the file as a downloadable HTTP response.
+     */
+    public function toResponse(?string $conversion = null): StreamedResponse
+    {
+        return $this->filesystem()->download(
+            $this->getPath($conversion ?? ''),
+            $this->file_name
+        );
+    }
+
+    /**
+     * Stream the file as an inline HTTP response (browsers display in-tab).
+     */
+    public function toInlineResponse(?string $conversion = null): StreamedResponse
+    {
+        return $this->filesystem()->response(
+            $this->getPath($conversion ?? ''),
+            $this->file_name
+        );
+    }
+
+    /**
+     * Open a read stream to the underlying file. Caller is responsible for closing it.
+     *
+     * @return resource
+     */
+    public function getStream(?string $conversion = null)
+    {
+        return $this->filesystem()->readStream(
+            $this->getPath($conversion ?? '')
+        );
+    }
+
+    /**
+     * Generate a temporary signed URL for cloud disks that support it.
+     *
+     * @throws TemporaryUrlNotSupported when the disk has no temporary URL support
+     */
+    public function getTemporaryUrl(?DateTimeInterface $expiration = null, ?string $conversion = null): string
+    {
+        $filesystem = $this->filesystem();
+
+        if (! method_exists($filesystem, 'providesTemporaryUrls') || ! $filesystem->providesTemporaryUrls()) {
+            throw TemporaryUrlNotSupported::forDisk($this->disk);
+        }
+
+        $expiration ??= now()->addMinutes(
+            (int) config('mediaman.temporary_url.default_lifetime_minutes', 5)
+        );
+
+        return $filesystem->temporaryUrl(
+            $this->getPath($conversion ?? ''),
+            $expiration
+        );
+    }
+
+    /**
+     * Build a Mail Attachment for use in Laravel Mailables.
+     * Pass an optional conversion name to attach a specific variant.
+     */
+    public function mailAttachment(?string $conversion = null): Attachment
+    {
+        return Attachment::fromStorageDisk($this->disk, $this->getPath($conversion ?? ''))
+            ->as($this->file_name)
+            ->withMime($this->mime_type);
+    }
+
+    /**
+     * Attachable contract method — Laravel calls this when $mailable->attach($media)
+     * is used. Returns the attachment for the original file (no conversion).
+     */
+    public function toMailAttachment(): Attachment
+    {
+        return $this->mailAttachment();
     }
 
     public function forgetCustomProperty(string $name): self

--- a/src/Traits/HasMedia.php
+++ b/src/Traits/HasMedia.php
@@ -301,6 +301,62 @@ trait HasMedia
     }
 
     /**
+     * Get the last media item in the specified channel.
+     */
+    public function getLastMedia(?string $channel = Media::DEFAULT_CHANNEL)
+    {
+        return $this->getMedia($channel)->last();
+    }
+
+    /**
+     * Get the URL of the last media item with automatic format detection.
+     */
+    public function getLastMediaUrl(?string $channel = Media::DEFAULT_CHANNEL, string $conversion = ''): string
+    {
+        if (! $media = $this->getLastMedia($channel)) {
+            return '';
+        }
+
+        return $media->getUrl($conversion);
+    }
+
+    /**
+     * Get the URL with fallback for the last media item.
+     */
+    public function getLastMediaUrlWithFallback(?string $channel = Media::DEFAULT_CHANNEL, string $conversion = ''): string
+    {
+        if (! $media = $this->getLastMedia($channel)) {
+            return '';
+        }
+
+        return $media->getUrlWithFallback($conversion);
+    }
+
+    /**
+     * Get conversion URL only if it exists for the last media item.
+     */
+    public function getLastMediaConversionUrl(?string $channel = Media::DEFAULT_CHANNEL, string $conversion = ''): ?string
+    {
+        if (! $media = $this->getLastMedia($channel)) {
+            return null;
+        }
+
+        return $media->getConversionUrl($conversion);
+    }
+
+    /**
+     * Check if the last media item has a specific conversion.
+     */
+    public function hasLastMediaConversion(?string $channel = Media::DEFAULT_CHANNEL, string $conversion = ''): bool
+    {
+        if (! $media = $this->getLastMedia($channel)) {
+            return false;
+        }
+
+        return $media->hasConversion($conversion);
+    }
+
+    /**
      * Register a new media group.
      */
     protected function addMediaChannel(string $name): MediaChannel

--- a/tests/Feature/GetLastMediaTest.php
+++ b/tests/Feature/GetLastMediaTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use Emaia\MediaMan\MediaUploader;
+use Emaia\MediaMan\Tests\Models\Subject;
+use Illuminate\Http\UploadedFile;
+
+beforeEach(function () {
+    $this->subject = Subject::create();
+
+    $media1 = MediaUploader::source(UploadedFile::fake()->image('first.jpg'))->upload();
+    $media2 = MediaUploader::source(UploadedFile::fake()->image('second.jpg'))->upload();
+    $media3 = MediaUploader::source(UploadedFile::fake()->image('third.jpg'))->upload();
+
+    $this->subject->syncMedia([$media1->id, $media2->id, $media3->id]);
+});
+
+// --- getLastMedia ---
+
+it('returns the last media item', function () {
+    $last = $this->subject->getLastMedia();
+
+    expect($last)->not->toBeNull()
+        ->and($last->name)->toEqual('third');
+});
+
+it('getLastMedia returns null for empty channel', function () {
+    $last = $this->subject->getLastMedia('other');
+
+    expect($last)->toBeNull();
+});
+
+// --- getLastMediaUrl ---
+
+it('returns the URL for the last media', function () {
+    $url = $this->subject->getLastMediaUrl();
+
+    expect($url)->toContain('third');
+});
+
+it('getLastMediaUrl returns empty string for empty channel', function () {
+    $url = $this->subject->getLastMediaUrl('other');
+
+    expect($url)->toEqual('');
+});
+
+it('getLastMediaUrl passes conversion to getUrl', function () {
+    $url = $this->subject->getLastMediaUrl('default', 'thumb');
+
+    expect($url)->not->toBeEmpty();
+});
+
+// --- getLastMediaUrlWithFallback ---
+
+it('returns fallback URL for last media', function () {
+    $url = $this->subject->getLastMediaUrlWithFallback();
+
+    expect($url)->not->toBeEmpty()
+        ->toContain('third');
+});
+
+it('getLastMediaUrlWithFallback returns empty string for empty channel', function () {
+    $url = $this->subject->getLastMediaUrlWithFallback('other');
+
+    expect($url)->toEqual('');
+});
+
+// --- getLastMediaConversionUrl ---
+
+it('returns null when conversion does not exist', function () {
+    $url = $this->subject->getLastMediaConversionUrl('default', 'nonexistent');
+
+    expect($url)->toBeNull();
+});
+
+it('getLastMediaConversionUrl returns null for empty channel', function () {
+    $url = $this->subject->getLastMediaConversionUrl('other', 'thumb');
+
+    expect($url)->toBeNull();
+});
+
+// --- hasLastMediaConversion ---
+
+it('returns false when conversion does not exist', function () {
+    $exists = $this->subject->hasLastMediaConversion('default', 'nonexistent');
+
+    expect($exists)->toBeFalse();
+});
+
+it('hasLastMediaConversion returns false for empty channel', function () {
+    $exists = $this->subject->hasLastMediaConversion('other', 'thumb');
+
+    expect($exists)->toBeFalse();
+});
+
+// --- Channel isolation ---
+
+it('getLastMedia respects channel isolation', function () {
+    $this->subject->attachMedia(
+        MediaUploader::source(UploadedFile::fake()->image('avatar.jpg'))->upload(),
+        'avatar'
+    );
+
+    $lastDefault = $this->subject->getLastMedia('default');
+    $lastAvatar = $this->subject->getLastMedia('avatar');
+
+    expect($lastDefault->name)->toEqual('third')
+        ->and($lastAvatar->name)->toEqual('avatar');
+});

--- a/tests/Feature/HttpResponseTest.php
+++ b/tests/Feature/HttpResponseTest.php
@@ -1,0 +1,151 @@
+<?php
+
+use Emaia\MediaMan\Exceptions\TemporaryUrlNotSupported;
+use Emaia\MediaMan\MediaUploader;
+use Emaia\MediaMan\Models\Media;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Mail\Attachment;
+use Illuminate\Support\Facades\Config;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+beforeEach(function () {
+    $file = UploadedFile::fake()->image('photo.jpg');
+    $this->media = MediaUploader::source($file)->upload();
+});
+
+// --- toResponse ---
+
+it('returns a StreamedResponse with content-disposition header', function () {
+    $response = $this->media->toResponse();
+
+    expect($response)->toBeInstanceOf(StreamedResponse::class);
+
+    $headers = $response->headers;
+
+    expect($headers->get('Content-Disposition'))
+        ->toContain('attachment')
+        ->toContain('photo.jpg');
+});
+
+it('toResponse streams the file content', function () {
+    $response = $this->media->toResponse();
+
+    ob_start();
+    $response->sendContent();
+    $content = ob_get_clean();
+
+    expect($content)->not->toBeEmpty();
+});
+
+// --- toInlineResponse ---
+
+it('returns an inline StreamedResponse', function () {
+    $response = $this->media->toInlineResponse();
+
+    expect($response)->toBeInstanceOf(StreamedResponse::class);
+
+    $disposition = $response->headers->get('Content-Disposition');
+
+    expect($disposition)->not->toContain('attachment');
+});
+
+it('toInlineResponse uses the file MIME type', function () {
+    $mime = $this->media->mime_type;
+
+    $response = $this->media->toInlineResponse();
+
+    expect($response->headers->get('Content-Type'))->toContain($mime);
+});
+
+// --- getStream ---
+
+it('returns a stream resource for the file', function () {
+    $stream = $this->media->getStream();
+
+    expect($stream)->toBeResource();
+
+    $contents = stream_get_contents($stream);
+    fclose($stream);
+
+    expect($contents)->not->toBeEmpty();
+});
+
+// --- getTemporaryUrl ---
+
+it('throws TemporaryUrlNotSupported on a local disk', function () {
+    $tmpDir = sys_get_temp_dir().'/mediaman_test_'.uniqid();
+    mkdir($tmpDir);
+
+    Config::set('filesystems.disks.tmp-test', [
+        'driver' => 'local',
+        'root' => $tmpDir,
+    ]);
+
+    $media = new Media;
+    $media->name = 'test';
+    $media->file_name = 'test.jpg';
+    $media->disk = 'tmp-test';
+    $media->mime_type = 'image/jpeg';
+    $media->size = 100;
+
+    try {
+        $media->getTemporaryUrl();
+    } finally {
+        array_map('unlink', glob("$tmpDir/*.*") ?: []);
+        rmdir($tmpDir);
+    }
+})->throws(TemporaryUrlNotSupported::class);
+
+it('getTemporaryUrl accepts an explicit expiration', function () {
+    $tmpDir = sys_get_temp_dir().'/mediaman_test_'.uniqid();
+    mkdir($tmpDir);
+
+    Config::set('filesystems.disks.tmp-test', [
+        'driver' => 'local',
+        'root' => $tmpDir,
+    ]);
+
+    $media = new Media;
+    $media->name = 'test';
+    $media->file_name = 'test.jpg';
+    $media->disk = 'tmp-test';
+    $media->mime_type = 'image/jpeg';
+    $media->size = 100;
+
+    try {
+        $media->getTemporaryUrl(now()->addHour());
+    } finally {
+        array_map('unlink', glob("$tmpDir/*.*") ?: []);
+        rmdir($tmpDir);
+    }
+})->throws(TemporaryUrlNotSupported::class);
+
+// --- mailAttachment ---
+
+it('returns an Attachment object', function () {
+    $attachment = $this->media->mailAttachment();
+
+    expect($attachment)->toBeInstanceOf(Attachment::class);
+});
+
+it('mailAttachment uses the media file_name as attachment name', function () {
+    $attachment = $this->media->mailAttachment();
+
+    expect($attachment->as)->toEqual($this->media->file_name);
+});
+
+it('mailAttachment uses the media mime_type', function () {
+    $attachment = $this->media->mailAttachment();
+
+    expect($attachment->mime)->toEqual($this->media->mime_type);
+});
+
+// --- Attachable interface (toMailAttachment) ---
+
+it('implements the Attachable interface via toMailAttachment', function () {
+    $attachment = $this->media->toMailAttachment();
+
+    expect($attachment)->toBeInstanceOf(Attachment::class)
+        ->and($attachment->as)->toEqual($this->media->file_name)
+        ->and($attachment->mime)->toEqual($this->media->mime_type);
+});


### PR DESCRIPTION
## Summary

- `Media::toResponse(?conversion)` / `toInlineResponse(?conversion)` — StreamedResponse for download / inline
- `Media::getStream(?conversion)` — returns a readable stream resource (caller closes)
- `Media::getTemporaryUrl(?expiration, ?conversion)` — signed URL with `providesTemporaryUrls()` capability detection; throws `TemporaryUrlNotSupported` on unsupported drivers
- `Media::mailAttachment(?conversion)` + `Media implements Attachable` — pass `$media` to `$mailable->attach()` directly
- `HasMedia::getLastMedia*` family mirroring `getFirstMedia*` (getLastMedia, getLastMediaUrl, getLastMediaUrlWithFallback, getLastMediaConversionUrl, hasLastMediaConversion)
- `temporary_url.default_lifetime_minutes` config (default 5)
- `TemporaryUrlNotSupported` exception
- README documents the new APIs and backfills a Security section catching up docs for v2.2 / v2.3 / v2.4 (extensions blocking, SSRF guard, mediaman:clean)

## Test plan

- [x] `composer test` — 464/464 (1 skip env-dependent)
- [x] `composer analyse` — clean
- [x] `vendor/bin/pint --test` — clean
- [ ] Manual smoke: route returns `$media->toResponse()` → browser downloads
- [ ] Manual smoke: route returns `$media->toInlineResponse()` → browser displays
- [ ] Manual smoke: `$mailable->attach($media)` sends email with attachment
- [ ] Manual smoke: `getTemporaryUrl()` on S3 disk → signed URL valid for expiration
- [ ] Manual smoke: `getTemporaryUrl()` on local disk → `TemporaryUrlNotSupported`
- [ ] Manual smoke: attach 3 media, `getLastMedia()` returns the third