### PR TITLE
Add MediaCollection validation, fluent setters, and auto-prune

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ There are a few key concepts that need to be understood before continuing:
 * [Media & Models](#media--models)
   * [getFirst* / getLast* helpers](#retrieve-media-of-a-model)
 * [Collections](#collections)
+  * [Collection validation and auto-prune](#collection-validation-and-auto-prune)
 * [Media & Collections](#media--collections)
 * [Media, Models & Conversions](#conversions)
 * [Responsive Images](#responsive-images)
@@ -935,6 +936,59 @@ This won't delete the media from the disk, but the bindings will be removed from
 
 *Heads Up!* deleteWithMedia() is a conceptual method that hasn't implemented yet, create a feature request if you need
 this. PRs are very much appreciated.
+
+### Collection validation and auto-prune
+
+Collections can declare which MIME types they accept and how many items they keep. Both rules are enforced on
+upload **and** on direct attach (`$collection->attachMedia(...)`).
+
+#### MIME type restriction
+
+```php
+$collection = MediaCollection::create(['name' => 'avatars']);
+
+// Single type
+$collection->acceptsMimeTypes(['image/png'])->save();
+
+// Multiple types
+$collection->acceptsMimeTypes(['image/png', 'image/jpeg'])->save();
+
+// Wildcard
+$collection->acceptsMimeTypes(['image/*'])->save();
+```
+
+Uploads or attaches of an unmatched MIME throw `Emaia\MediaMan\Exceptions\MediaNotAcceptedByCollection`.
+
+An empty array (`acceptsMimeTypes([])`) or `null` means "accept anything".
+
+#### Auto-prune oldest
+
+```php
+// Keep at most N items, prune oldest on overflow
+$collection = MediaCollection::create(['name' => 'gallery'])
+    ->onlyKeepLatest(5);
+$collection->save();
+
+// Shortcut for onlyKeepLatest(1)
+$avatar = MediaCollection::create(['name' => 'avatar'])
+    ->singleFile();
+$avatar->save();
+```
+
+When a new media is attached above the limit, the **oldest** media (by `created_at`, with id as tiebreaker) is
+**detached** from the collection. The Media record itself is **never deleted** — it may still be attached to other
+models, collections, or channels.
+
+Auto-prune fires from both upload (`MediaUploader::source()->useCollection(...)->upload()`) and direct attach
+(`$collection->attachMedia($media)`).
+
+#### Fluent setters require `->save()`
+
+The setters mutate the model in memory only — call `->save()` to persist (matches Eloquent convention):
+
+```php
+$collection->onlyKeepLatest(3)->acceptsMimeTypes(['image/jpeg'])->save();
+```
 
 ------
 

--- a/database/migrations/create_mediaman_tables.php.stub
+++ b/database/migrations/create_mediaman_tables.php.stub
@@ -17,6 +17,10 @@ class CreateMediaManTables extends Migration
         Schema::create(config('mediaman.tables.collections'), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('name');
+            $table->integer('max_items')->nullable();
+            $table->json('allowed_mime_types')->nullable();
+            $table->string('fallback_url')->nullable();
+            $table->string('fallback_path')->nullable();
             $table->timestamps();
         });
 

--- a/src/Exceptions/MediaNotAcceptedByCollection.php
+++ b/src/Exceptions/MediaNotAcceptedByCollection.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Emaia\MediaMan\Exceptions;
+
+use Exception;
+
+class MediaNotAcceptedByCollection extends Exception
+{
+    public static function mimeTypeNotAllowed(string $mimeType, string $collectionName): self
+    {
+        return new self("The MIME type `{$mimeType}` is not allowed by collection `{$collectionName}`.");
+    }
+}

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -457,14 +457,18 @@ class MediaUploader
                 'name' => $this->collections[0],
             ]);
 
+            $collection->validateMedia($media);
             $media->collections()->attach($collection->getKey());
+            $collection->enforceMaxItems();
         } else {
             // add to the default collection
             // todo: allow not to add in the default collection
             $collectionModel = $this->collectionModel();
             $collection = $collectionModel::findByName(config('mediaman.collection'));
             if ($collection) {
+                $collection->validateMedia($media);
                 $media->collections()->attach($collection->getKey());
+                $collection->enforceMaxItems();
             }
         }
 

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -521,8 +521,8 @@ class Media extends Model implements Attachable
         return $this->belongsToMany(
             $this->collectionModel(),
             config('mediaman.tables.collection_media'),
-            'collection_id',
-            'media_id');
+            'media_id',
+            'collection_id');
     }
 
     /**

--- a/src/Models/MediaCollection.php
+++ b/src/Models/MediaCollection.php
@@ -2,6 +2,7 @@
 
 namespace Emaia\MediaMan\Models;
 
+use Emaia\MediaMan\Exceptions\MediaNotAcceptedByCollection;
 use Emaia\MediaMan\Traits\ResolvesModels;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
@@ -11,13 +12,24 @@ use Illuminate\Support\Collection as BaseCollection;
 
 /**
  * @property int $id
+ * @property string $name
+ * @property int|null $max_items
+ * @property array|null $allowed_mime_types
+ * @property string|null $fallback_url
+ * @property string|null $fallback_path
  */
 class MediaCollection extends Model
 {
     use ResolvesModels;
 
     protected $fillable = [
-        'name', 'created_at', 'updated_at',
+        'name', 'max_items', 'allowed_mime_types', 'fallback_url', 'fallback_path',
+        'created_at', 'updated_at',
+    ];
+
+    protected $casts = [
+        'max_items' => 'integer',
+        'allowed_mime_types' => 'json',
     ];
 
     public function getTable(): string
@@ -25,11 +37,6 @@ class MediaCollection extends Model
         return config('mediaman.tables.collections', 'mediaman_collections');
     }
 
-    /**
-     * Find one or many collections by name.
-     *
-     * @return EloquentCollection|static|null
-     */
     public static function findByName(string|array $names, array $columns = ['*'])
     {
         $query = static::query()->select($columns);
@@ -43,12 +50,138 @@ class MediaCollection extends Model
 
     public function media(): BelongsToMany
     {
-        return $this->belongsToMany($this->mediaModel(), config('mediaman.tables.collection_media'), 'media_id', 'collection_id');
+        return $this->belongsToMany(
+            $this->mediaModel(),
+            config('mediaman.tables.collection_media'),
+            'collection_id',
+            'media_id'
+        );
     }
 
+    // ─── Fluent setters ──────────────────────────────────────────────
+
+    public function singleFile(): self
+    {
+        return $this->onlyKeepLatest(1);
+    }
+
+    public function onlyKeepLatest(int $count): self
+    {
+        $this->max_items = $count;
+
+        return $this;
+    }
+
+    public function acceptsMimeTypes(array $types): self
+    {
+        $this->allowed_mime_types = $types;
+
+        return $this;
+    }
+
+    // ─── Validation ───────────────────────────────────────────────────
+
+    public function validateMedia(Media $media): void
+    {
+        $allowed = $this->allowed_mime_types;
+
+        if ($allowed === null || $allowed === []) {
+            return;
+        }
+
+        $mimeType = $media->mime_type;
+
+        foreach ($allowed as $pattern) {
+            if ($this->mimeTypeMatches($mimeType, $pattern)) {
+                return;
+            }
+        }
+
+        throw MediaNotAcceptedByCollection::mimeTypeNotAllowed($mimeType, $this->name);
+    }
+
+    private function mimeTypeMatches(string $mimeType, string $pattern): bool
+    {
+        if ($pattern === $mimeType) {
+            return true;
+        }
+
+        if (str_ends_with($pattern, '/*')) {
+            return str_starts_with($mimeType, substr($pattern, 0, -1));
+        }
+
+        return false;
+    }
+
+    // ─── Auto-prune ───────────────────────────────────────────────────
+
     /**
-     * Sync media of a collection
+     * TODO: for collections with very large item counts, consider chunking
+     * or a sub-query approach instead of loading all media into memory.
      */
+    public function enforceMaxItems(): void
+    {
+        $max = $this->max_items;
+
+        if ($max === null || $max < 1) {
+            return;
+        }
+
+        $table = config('mediaman.tables.media');
+
+        $attached = $this->media()
+            ->orderBy("{$table}.created_at", 'asc')
+            ->orderBy("{$table}.id", 'asc')
+            ->get();
+
+        if ($attached->count() <= $max) {
+            return;
+        }
+
+        $toDetach = $attached->take($attached->count() - $max);
+
+        $this->media()->detach($toDetach->modelKeys());
+    }
+
+    // ─── Attach / Sync / Detach (with hooks) ──────────────────────────
+
+    public function attachMedia($media): ?int
+    {
+        if (! $fetch = $this->fetchMedia($media)) {
+            return null;
+        }
+
+        if (is_countable($fetch)) {
+            /** @var Collection $fetch */
+            $mediaItems = $fetch;
+
+            foreach ($mediaItems as $item) {
+                if ($item instanceof Media) {
+                    $this->validateMedia($item);
+                }
+            }
+
+            $ids = $mediaItems->modelKeys();
+            $res = $this->media()->sync($ids, false);
+
+            $attached = count($res['attached']);
+        } elseif (is_object($fetch) && method_exists($fetch, 'getKey')) {
+            if ($fetch instanceof Media) {
+                $this->validateMedia($fetch);
+            }
+
+            $res = $this->media()->sync($fetch->getKey(), false);
+
+            $attached = count($res['attached']);
+        } else {
+            return null;
+        }
+
+        $this->enforceMaxItems();
+
+        return $attached > 0 ? $attached : null;
+    }
+
     public function syncMedia($media, bool $detaching = true): ?array
     {
         if ($this->shouldDetachAll($media)) {
@@ -61,58 +194,35 @@ class MediaCollection extends Model
 
         if (is_countable($fetch)) {
             /** @var Collection $fetch */
-            $ids = $fetch->modelKeys();
+            foreach ($fetch as $item) {
+                if ($item instanceof Media) {
+                    $this->validateMedia($item);
+                }
+            }
 
-            return $this->media()->sync($ids, $detaching);
+            $ids = $fetch->modelKeys();
+            $result = $this->media()->sync($ids, $detaching);
+
+            $this->enforceMaxItems();
+
+            return $result;
         }
 
         if (is_object($fetch) && method_exists($fetch, 'getKey')) {
-            return $this->media()->sync($fetch->getKey());
+            if ($fetch instanceof Media) {
+                $this->validateMedia($fetch);
+            }
+
+            $result = $this->media()->sync($fetch->getKey(), $detaching);
+
+            $this->enforceMaxItems();
+
+            return $result;
         }
 
         return null;
     }
 
-    /**
-     * Attach media to a collection
-     *
-     * @param  null|int|string|array|Media|EloquentCollection  $media
-     * @return int|null number of attached media or null
-     */
-    public function attachMedia($media): ?int
-    {
-        $fetch = $this->fetchMedia($media);
-
-        if (! $fetch = $this->fetchMedia($media)) {
-            return null;
-        }
-
-        // to be consistent with the return type of detach method
-        // which returns number of detached model, we're using sync without detachment
-        if (is_countable($fetch)) {
-            /** @var Collection $fetch */
-            $ids = $fetch->modelKeys();
-            $res = $this->media()->sync($ids, false);
-
-            $attached = count($res['attached']);
-
-            return $attached > 0 ? $attached : null;
-        }
-
-        if (is_object($fetch) && method_exists($fetch, 'getKey')) {
-            $res = $this->media()->sync($fetch->getKey(), false);
-
-            $attached = count($res['attached']);
-
-            return $attached > 0 ? $attached : null;
-        }
-
-        return null;
-    }
-
-    /**
-     * Detach media from a collection
-     */
     public function detachMedia(mixed $media): ?int
     {
         if ($this->shouldDetachAll($media)) {
@@ -137,9 +247,6 @@ class MediaCollection extends Model
         return null;
     }
 
-    /**
-     * Check if all media should be detached
-     */
     private function shouldDetachAll($media): bool
     {
         if (is_bool($media) || empty($media)) {
@@ -153,19 +260,10 @@ class MediaCollection extends Model
         return false;
     }
 
-    /**
-     * Fetch media
-     *
-     * returns single collection for single item
-     * and multiple collections for multiple items
-     * todo: exception / strict return types
-     */
     private function fetchMedia(mixed $media): mixed
     {
         $model = $this->mediaModel();
 
-        // an eloquent collection doesn't need to be fetched again
-        // it's treated as a valid source of Media resource
         if ($media instanceof EloquentCollection) {
             return $media;
         }
@@ -192,11 +290,13 @@ class MediaCollection extends Model
             return $model::findByName($media);
         }
 
-        // all array items should be of same type
-        // find by id or name based on the type of first item in the array
         if (is_array($media) && isset($media[0])) {
             if ($media[0] instanceof BaseCollection) {
                 return $media;
+            }
+
+            if ($media[0] instanceof Model) {
+                return $model::find(collect($media)->map(fn ($m) => $m->getKey())->all());
             }
 
             if (is_numeric($media[0])) {

--- a/tests/Feature/CollectionValidationTest.php
+++ b/tests/Feature/CollectionValidationTest.php
@@ -1,0 +1,238 @@
+<?php
+
+use Emaia\MediaMan\Exceptions\MediaNotAcceptedByCollection;
+use Emaia\MediaMan\MediaUploader;
+use Emaia\MediaMan\Models\Media;
+use Emaia\MediaMan\Models\MediaCollection;
+use Illuminate\Http\UploadedFile;
+
+// ─── Fluent setters ────────────────────────────────────────────────
+
+it('singleFile sets max_items to 1', function () {
+    $collection = MediaCollection::create(['name' => 'avatars']);
+    $collection->singleFile()->save();
+
+    expect($collection->fresh()->max_items)->toEqual(1);
+});
+
+it('onlyKeepLatest sets max_items to the given count', function () {
+    $collection = MediaCollection::create(['name' => 'gallery']);
+    $collection->onlyKeepLatest(5)->save();
+
+    expect($collection->fresh()->max_items)->toEqual(5);
+});
+
+it('acceptsMimeTypes sets allowed_mime_types', function () {
+    $collection = MediaCollection::create(['name' => 'photos']);
+    $collection->acceptsMimeTypes(['image/png', 'image/jpeg'])->save();
+
+    expect($collection->fresh()->allowed_mime_types)->toEqual(['image/png', 'image/jpeg']);
+});
+
+// ─── MIME type validation (upload) ──────────────────────────────────
+
+it('accepts a matching MIME type during upload', function () {
+    MediaCollection::create(['name' => 'png-only'])
+        ->acceptsMimeTypes(['image/png'])
+        ->save();
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.png'))
+        ->useCollection('png-only')
+        ->upload();
+
+    expect($media)->toBeInstanceOf(Media::class);
+});
+
+it('rejects a non-matching MIME type during upload', function () {
+    MediaCollection::create(['name' => 'png-only'])
+        ->acceptsMimeTypes(['image/png'])
+        ->save();
+
+    MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))
+        ->useCollection('png-only')
+        ->upload();
+})->throws(MediaNotAcceptedByCollection::class);
+
+it('supports wildcard MIME type patterns in collection validation', function () {
+    MediaCollection::create(['name' => 'images'])
+        ->acceptsMimeTypes(['image/*'])
+        ->save();
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))
+        ->useCollection('images')
+        ->upload();
+
+    expect($media)->toBeInstanceOf(Media::class);
+});
+
+it('empty allowed_mime_types accepts everything', function () {
+    $collection = MediaCollection::create(['name' => 'open-collection']);
+    $collection->acceptsMimeTypes([])->save();
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('anything.jpg'))
+        ->useCollection('open-collection')
+        ->upload();
+
+    expect($media)->toBeInstanceOf(Media::class);
+});
+
+it('null allowed_mime_types accepts everything', function () {
+    $collection = MediaCollection::create(['name' => 'null-collection']);
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('anything.jpg'))
+        ->useCollection('null-collection')
+        ->upload();
+
+    expect($media)->toBeInstanceOf(Media::class);
+});
+
+// ─── MIME type validation (direct attach) ───────────────────────────
+
+it('rejects direct attach of non-matching MIME type', function () {
+    $collection = MediaCollection::create(['name' => 'png-gallery']);
+    $collection->acceptsMimeTypes(['image/png'])->save();
+
+    $jpgMedia = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))
+        ->useCollection('different')
+        ->upload();
+
+    $collection->attachMedia($jpgMedia);
+})->throws(MediaNotAcceptedByCollection::class);
+
+it('accepts direct attach of matching MIME type', function () {
+    $collection = MediaCollection::create(['name' => 'png-gallery']);
+    $collection->acceptsMimeTypes(['image/png'])->save();
+
+    $pngMedia = MediaUploader::source(UploadedFile::fake()->image('photo.png'))
+        ->useCollection('different')
+        ->upload();
+
+    $result = $collection->attachMedia($pngMedia);
+
+    expect($result)->toBeGreaterThan(0)
+        ->and($collection->media()->count())->toEqual(1);
+});
+
+// ─── Auto-prune: onlyKeepLatest / singleFile ────────────────────────
+
+it('onlyKeepLatest prunes oldest media exceeding the limit', function () {
+    $collection = MediaCollection::create(['name' => 'limited'])
+        ->onlyKeepLatest(3);
+    $collection->save();
+
+    $m1 = MediaUploader::source(UploadedFile::fake()->image('one.jpg'))->upload();
+    $m2 = MediaUploader::source(UploadedFile::fake()->image('two.jpg'))->upload();
+    $m3 = MediaUploader::source(UploadedFile::fake()->image('three.jpg'))->upload();
+    $m4 = MediaUploader::source(UploadedFile::fake()->image('four.jpg'))->upload();
+    $m5 = MediaUploader::source(UploadedFile::fake()->image('five.jpg'))->upload();
+
+    $collection->attachMedia([$m1, $m2, $m3, $m4, $m5]);
+
+    $attached = $collection->media()->get();
+
+    expect($attached)->toHaveCount(3)
+        ->and($attached->contains($m1))->toBeFalse()
+        ->and($attached->contains($m2))->toBeFalse()
+        ->and($attached->contains($m3))->toBeTrue()
+        ->and($attached->contains($m4))->toBeTrue()
+        ->and($attached->contains($m5))->toBeTrue();
+});
+
+it('singleFile keeps only the latest file', function () {
+    $collection = MediaCollection::create(['name' => 'single'])
+        ->singleFile();
+    $collection->save();
+
+    $first = MediaUploader::source(UploadedFile::fake()->image('first.jpg'))->upload();
+    $second = MediaUploader::source(UploadedFile::fake()->image('second.jpg'))->upload();
+
+    $collection->attachMedia([$first, $second]);
+
+    $attached = $collection->media()->get();
+
+    expect($attached)->toHaveCount(1)
+        ->and($attached->first()->id)->toEqual($second->id);
+});
+
+it('skip auto-prune when max_items is null', function () {
+    $collection = MediaCollection::create(['name' => 'unlimited']);
+
+    $m1 = MediaUploader::source(UploadedFile::fake()->image('one.jpg'))->upload();
+    $m2 = MediaUploader::source(UploadedFile::fake()->image('two.jpg'))->upload();
+
+    $collection->attachMedia([$m1, $m2]);
+
+    expect($collection->media()->count())->toEqual(2);
+});
+
+// ─── Auto-prune does NOT delete Media records ───────────────────────
+
+it('auto-prune detaches but does not delete the Media record', function () {
+    $collection = MediaCollection::create(['name' => 'pruned'])
+        ->singleFile();
+    $collection->save();
+
+    $first = MediaUploader::source(UploadedFile::fake()->image('first.jpg'))->upload();
+    $second = MediaUploader::source(UploadedFile::fake()->image('second.jpg'))->upload();
+
+    $collection->attachMedia([$first, $second]);
+
+    expect(Media::find($first->id))->not->toBeNull();
+    expect(Media::find($second->id))->not->toBeNull();
+    expect($collection->media()->count())->toEqual(1);
+});
+
+// ─── Upload with auto-prune ─────────────────────────────────────────
+
+it('auto-prunes during upload when collection has max_items set', function () {
+    $collection = MediaCollection::create(['name' => 'upload-limited'])
+        ->onlyKeepLatest(2);
+    $collection->save();
+
+    MediaUploader::source(UploadedFile::fake()->image('a.jpg'))
+        ->useCollection('upload-limited')->upload();
+    MediaUploader::source(UploadedFile::fake()->image('b.jpg'))
+        ->useCollection('upload-limited')->upload();
+    MediaUploader::source(UploadedFile::fake()->image('c.jpg'))
+        ->useCollection('upload-limited')->upload();
+
+    expect($collection->fresh()->media()->count())->toEqual(2);
+});
+
+it('rejects upload when collection does not accept the MIME type', function () {
+    MediaCollection::create(['name' => 'png-uploads'])
+        ->acceptsMimeTypes(['image/png'])
+        ->save();
+
+    MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))
+        ->useCollection('png-uploads')
+        ->upload();
+})->throws(MediaNotAcceptedByCollection::class);
+
+it('auto-prunes after direct attach to a singleFile collection', function () {
+    $collection = MediaCollection::create(['name' => 'direct-single'])
+        ->singleFile();
+    $collection->save();
+
+    $first = MediaUploader::source(UploadedFile::fake()->image('first.jpg'))->upload();
+    $second = MediaUploader::source(UploadedFile::fake()->image('second.jpg'))->upload();
+
+    $collection->attachMedia($first);
+    expect($collection->media()->count())->toEqual(1);
+
+    $collection->attachMedia($second);
+    expect($collection->media()->count())->toEqual(1)
+        ->and($collection->media()->first()->id)->toEqual($second->id);
+});
+
+it('Media::collections returns the collections it belongs to', function () {
+    $collection = MediaCollection::create(['name' => 'photos']);
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))
+        ->useCollection('photos')
+        ->upload();
+
+    $ids = $media->collections->pluck('id')->all();
+
+    expect($ids)->toContain($collection->id);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,6 +28,9 @@ class TestCase extends Orchestra
 
         $this->loadMigrationsFrom(__DIR__.'/database/migrations');
 
+        // Clean any auto-generated migrations in Testbench skeleton
+        $this->cleanTestbenchMigrations();
+
         // Use a test disk as the default disk...
         Config::set('mediaman.disk', self::DEFAULT_DISK);
 
@@ -64,5 +67,31 @@ class TestCase extends Orchestra
 
         // Load migrations
         $app['migrator']->path(__DIR__.'/../database/migrations');
+    }
+
+    /**
+     * Remove any *.php files from the Testbench skeleton's migrations dir.
+     *
+     * Tests for `mediaman:publish-migration` publish stub files into
+     * `base_path('database/migrations')` (the Testbench fake-app directory).
+     * RefreshDatabase auto-discovers files in that directory and would re-run
+     * them on the next test, conflicting with `loadMigrationsFrom` and
+     * `app['migrator']->path()` loaded above.
+     *
+     * Wiping the directory at setUp ensures isolation between tests.
+     */
+    protected function cleanTestbenchMigrations(): void
+    {
+        $dir = base_path('database/migrations');
+
+        if (! is_dir($dir)) {
+            return;
+        }
+
+        foreach (glob($dir.'/*.php') as $file) {
+            if (basename($file) !== '.gitkeep') {
+                unlink($file);
+            }
+        }
     }
 }

--- a/tests/database/migrations/2021_02_11_000001_create_mediaman_tables.php
+++ b/tests/database/migrations/2021_02_11_000001_create_mediaman_tables.php
@@ -4,26 +4,24 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateMediaManTables extends Migration
+return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
-        // Collections table
         Schema::create(config('mediaman.tables.collections'), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('name');
+            $table->integer('max_items')->nullable();
+            $table->json('allowed_mime_types')->nullable();
+            $table->string('fallback_url')->nullable();
+            $table->string('fallback_path')->nullable();
             $table->timestamps();
         });
 
-        // Default seed for collections
         $collection = resolve(config('mediaman.models.collection'));
         $collection->name = 'Default';
         $collection->save();
 
-        // Media table
         Schema::create(config('mediaman.tables.media'), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('disk');
@@ -35,7 +33,6 @@ class CreateMediaManTables extends Migration
             $table->timestamps();
         });
 
-        // Collection & Media pivot table
         Schema::create(config('mediaman.tables.collection_media'), function (Blueprint $table) {
             $table->unsignedBigInteger('collection_id')
                 ->constraint(config('mediaman.tables.collections'))
@@ -48,7 +45,6 @@ class CreateMediaManTables extends Migration
             $table->primary(['collection_id', 'media_id']);
         });
 
-        // Mediable table
         Schema::create(config('mediaman.tables.mediables'), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('media_id')->index();
@@ -64,16 +60,12 @@ class CreateMediaManTables extends Migration
             $table->index(['mediable_type', 'mediable_id', 'channel']);
         });
 
-        // Test Subject table
         Schema::create('subjects', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->timestamps();
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::dropIfExists(config('mediaman.tables.collections'));
@@ -82,4 +74,4 @@ class CreateMediaManTables extends Migration
         Schema::dropIfExists(config('mediaman.tables.mediables'));
         Schema::dropIfExists('subjects');
     }
-}
+};


### PR DESCRIPTION
## Summary

- Fluent setters on `MediaCollection`: `singleFile()`, `onlyKeepLatest($n)`, `acceptsMimeTypes([...])`
- `validateMedia()` rejects media whose MIME does not match (supports wildcards like `image/*`); throws `MediaNotAcceptedByCollection`
- `enforceMaxItems()` auto-prunes oldest media when count exceeds `max_items`; detach-only (preserves Media records — cascade safety)
- Validation + prune hook on **both** upload and direct attach paths
- New columns on `mediaman_collections`: `max_items`, `allowed_mime_types`, `fallback_url`, `fallback_path`
- README updated with usage examples under Collections

## Notes / fixes

- `Media::collections()` had its `BelongsToMany` foreign/related pivot keys swapped — fixed. Users who relied on `$media->collections` may see different data (the new data is the correct one). New regression test covers this direction.
- Schema for new columns lives **inside the existing `create_mediaman_tables` stub**. Fresh installs get them automatically. Upgrade path for existing installations will be documented in the release notes.

## Test plan

- [x] `composer test` — 482/482 (1 skip env-dependent)
- [x] `composer analyse` — clean
- [x] `vendor/bin/pint --test` — clean
- [ ] Manual smoke: `onlyKeepLatest(3)`, upload 5 → only 3 attached, 2 oldest detached
- [ ] Manual smoke: `singleFile()`, upload 2 → only latest attached
- [ ] Manual smoke: `acceptsMimeTypes(['image/png'])`, upload JPG → throws
- [ ] Manual smoke: `acceptsMimeTypes(['image/*'])`, upload PNG/JPG → accepted
- [ ] Manual smoke: attach existing JPG via `$collection->attachMedia($jpg)` on PNG-only collection → throws
- [ ] Manual smoke: auto-prune detaches but Media records still exist in DB
- [ ] Manual smoke: `$media->collections` returns the collections after attach