### PR TITLE
Add ordering, fallback URLs/paths, Media::copy, Media::attachTo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,11 @@ There are a few key concepts that need to be understood before continuing:
   * [Upload from other sources](#upload-from-other-sources)
   * [HTTP responses & mail](#http-responses--mail)
   * [Custom Properties](#custom-properties)
+  * [Copy and re-attach media](#copy-and-re-attach-media)
 * [Media & Models](#media--models)
   * [getFirst* / getLast* helpers](#retrieve-media-of-a-model)
+  * [Ordering media](#ordering-media)
+  * [Channel fallbacks](#channel-fallbacks)
 * [Collections](#collections)
   * [Collection validation and auto-prune](#collection-validation-and-auto-prune)
 * [Media & Collections](#media--collections)
@@ -682,6 +685,29 @@ $media->save();
 **Tip**: Enabling this check can preemptively spot storage issues but may add minor operational delays. Consider your
 system's needs and decide accordingly.
 
+### Copy and re-attach media
+
+`Media::copy()` clones a Media record, copies the physical file (plus conversions and responsive variants), and
+attaches the new copy to the target model. The original Media stays untouched.
+
+```php
+$copy = $media->copy($otherPost, 'featured');
+// $copy is a new Media row with a fresh id; both files exist on disk
+```
+
+If any file copy fails, the new Media DB record is rolled back so you don't end up with an orphan record. The target
+model must use the `HasMedia` trait — otherwise `Emaia\MediaMan\Exceptions\InvalidCopyTarget` is thrown.
+
+When source and target are on different disks, `copy()` streams files (`readStream` → `writeStream`) instead of
+loading them fully into memory.
+
+`Media::attachTo()` re-attaches the same Media to another model **without** touching disk — it's purely a pivot
+write, useful when you want the same file referenced from multiple models:
+
+```php
+$media->attachTo($otherPost, 'gallery'); // chainable, returns $media
+```
+
 ### Delete media
 
 You can delete a media by calling the delete() method on an instance of Media.
@@ -861,7 +887,7 @@ $post->clearMediaChannel('channel-name');
 
 You can sync media of a specified channel using the syncMedia() method. This provides a flexible way to maintain the
 association between your model and the related media records. The default method signature look like this:
-`syncMedia($media, string $channel = 'default', array $conversions = [], $detaching = true)`
+`syncMedia($media, string $channel = 'default', array $conversions = [], $detaching = true, ?int $startOrder = null)`
 
 This will remove the media that aren't in the provided list and add those which aren't already attached if $detaching is
 truthy.
@@ -876,6 +902,65 @@ $post->syncMedia($media);
 
 **Heads Up!:** None of the attachMedia, detachMedia, or syncMedia methods deletes the file, it just does as it means.
 Refer to delete a media section to know how to delete a media.
+
+### Ordering media
+
+The pivot table stores an `order_column` per attachment. When you call `attachMedia()` without an explicit position,
+media gets the next sequential slot (`max(order_column) + 1` for the channel). `getMedia()` and friends return rows
+ordered by `order_column` ascending, with `NULL` rows sorted **last** (cross-DB).
+
+```php
+// Auto-assigned sequential order: 0, 1, 2
+$post->attachMedia($m1);
+$post->attachMedia($m2);
+$post->attachMedia($m3);
+
+// Explicit starting position
+$post->attachMedia($m4, 'gallery', [], 10);          // pivot order_column = 10
+$post->attachMedia([$m5, $m6], 'gallery', [], 20);   // 20 and 21
+
+// Batch reorder a channel — positions become 0, 1, 2 in the array order
+$post->setMediaOrder([$m3->id, $m1->id, $m2->id]);
+
+// Scoped to a specific channel
+$post->setMediaOrder([$mB->id, $mA->id], 'gallery');
+```
+
+`setMediaOrder()` runs in a DB transaction. It throws `InvalidArgumentException` if any id is not currently attached
+to the model in the given channel.
+
+### Channel fallbacks
+
+A media channel can declare a fallback URL or path used when the channel has no media attached. Configure via
+`registerMediaChannels()` (or ad-hoc with `addMediaChannel()`):
+
+```php
+public function registerMediaChannels(): void
+{
+    $this->addMediaChannel('avatar')
+        ->useFallbackUrl('/img/default-avatar.png')
+        ->useFallbackPath(public_path('img/default-avatar.png'));
+}
+```
+
+`getFirstMediaUrl()`, `getFirstMediaUrlWithFallback()`, `getFirstMediaPath()`, and the matching `getLastMedia*`
+helpers return the configured fallback when the channel is empty:
+
+```php
+$post->getFirstMediaUrl('avatar');   // '/img/default-avatar.png' when no media attached
+$post->getFirstMediaPath('avatar');  // '/var/www/.../public/img/default-avatar.png'
+```
+
+Per-conversion overrides take precedence over the channel default:
+
+```php
+$this->addMediaChannel('avatar')
+    ->useFallbackUrl('/img/default-avatar.png')
+    ->useFallbackUrl('/img/avatar-thumb.png', 'thumb');
+
+$post->getFirstMediaUrl('avatar');          // '/img/default-avatar.png'
+$post->getFirstMediaUrl('avatar', 'thumb'); // '/img/avatar-thumb.png'
+```
 
 -----
 

--- a/database/migrations/create_mediaman_tables.php.stub
+++ b/database/migrations/create_mediaman_tables.php.stub
@@ -61,6 +61,7 @@ class CreateMediaManTables extends Migration
             $table->unsignedBigInteger('mediable_id')->index();
             $table->string('mediable_type');
             $table->string('channel');
+            $table->integer('order_column')->nullable()->index();
 
             $table->foreign('media_id')
                 ->references('id')

--- a/src/Exceptions/InvalidCopyTarget.php
+++ b/src/Exceptions/InvalidCopyTarget.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Emaia\MediaMan\Exceptions;
+
+use Exception;
+
+class InvalidCopyTarget extends Exception
+{
+    public static function missingTrait(): self
+    {
+        return new self('Target model must use the HasMedia trait.');
+    }
+}

--- a/src/MediaChannel.php
+++ b/src/MediaChannel.php
@@ -6,11 +6,16 @@ class MediaChannel
 {
     protected array $conversions = [];
 
-    /**
-     * Register the conversions to be performed when media is attached.
-     *
-     * @return $this
-     */
+    protected string $fallbackUrl = '';
+
+    protected string $fallbackPath = '';
+
+    /** @var array<string, string> */
+    protected array $conversionFallbackUrls = [];
+
+    /** @var array<string, string> */
+    protected array $conversionFallbackPaths = [];
+
     public function performConversions(string ...$conversions): MediaChannel
     {
         $this->conversions = $conversions;
@@ -18,19 +23,53 @@ class MediaChannel
         return $this;
     }
 
-    /**
-     * Determine if there are any registered conversions.
-     */
     public function hasConversions(): bool
     {
         return ! empty($this->conversions);
     }
 
-    /**
-     * Get all the registered conversions.
-     */
     public function getConversions(): array
     {
         return $this->conversions;
+    }
+
+    public function useFallbackUrl(string $url, ?string $conversion = null): MediaChannel
+    {
+        if ($conversion === null) {
+            $this->fallbackUrl = $url;
+        } else {
+            $this->conversionFallbackUrls[$conversion] = $url;
+        }
+
+        return $this;
+    }
+
+    public function useFallbackPath(string $path, ?string $conversion = null): MediaChannel
+    {
+        if ($conversion === null) {
+            $this->fallbackPath = $path;
+        } else {
+            $this->conversionFallbackPaths[$conversion] = $path;
+        }
+
+        return $this;
+    }
+
+    public function getFallbackUrl(?string $conversion = null): string
+    {
+        if ($conversion !== null && isset($this->conversionFallbackUrls[$conversion])) {
+            return $this->conversionFallbackUrls[$conversion];
+        }
+
+        return $this->fallbackUrl;
+    }
+
+    public function getFallbackPath(?string $conversion = null): string
+    {
+        if ($conversion !== null && isset($this->conversionFallbackPaths[$conversion])) {
+            return $this->conversionFallbackPaths[$conversion];
+        }
+
+        return $this->fallbackPath;
     }
 }

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -9,6 +9,7 @@ use Emaia\MediaMan\Database\Factories\MediaFactory;
 use Emaia\MediaMan\Enums\MediaFormat;
 use Emaia\MediaMan\Enums\MediaType;
 use Emaia\MediaMan\Events\MediaDeleted;
+use Emaia\MediaMan\Exceptions\InvalidCopyTarget;
 use Emaia\MediaMan\Exceptions\TemporaryUrlNotSupported;
 use Emaia\MediaMan\Traits\ResolvesModels;
 use Emaia\MediaMan\Traits\ResponsiveImages;
@@ -27,6 +28,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Throwable;
 
 /**
  * @property int $id
@@ -745,5 +747,133 @@ class Media extends Model implements Attachable
         $this->custom_properties = $customProperties;
 
         return $this;
+    }
+
+    /**
+     * Copy this media to another model.
+     *
+     * Creates a new Media record, copies the physical file (and conversions
+     * and responsive variants), and attaches it to the target model. If any
+     * file copy fails, the new Media record is rolled back.
+     */
+    public function copy(object $target, string $channel = self::DEFAULT_CHANNEL): Media
+    {
+        if (! method_exists($target, 'attachMedia')) {
+            throw InvalidCopyTarget::missingTrait();
+        }
+
+        $copy = $this->replicate(['id']);
+        $copy->save();
+
+        try {
+            $this->copyPrimaryFile($copy);
+            $this->copyConversions($copy);
+            $this->copyResponsiveVariants($copy);
+        } catch (Throwable $e) {
+            $copy->delete();
+
+            throw $e;
+        }
+
+        $target->attachMedia($copy, $channel);
+
+        return $copy;
+    }
+
+    /**
+     * Attach this media to another model without duplicating the file.
+     *
+     * This is a purely relational operation — it does not touch the file on disk.
+     * To move between disks, change the `disk` attribute instead.
+     */
+    public function attachTo(object $target, string $channel = self::DEFAULT_CHANNEL): self
+    {
+        if (! method_exists($target, 'attachMedia')) {
+            throw InvalidCopyTarget::missingTrait();
+        }
+
+        $target->attachMedia($this, $channel);
+
+        return $this;
+    }
+
+    protected function copyPrimaryFile(Media $target): void
+    {
+        if ($this->disk === $target->disk) {
+            $this->filesystem()->copy($this->getPath(), $target->getPath());
+
+            return;
+        }
+
+        $stream = $this->filesystem()->readStream($this->getPath());
+
+        try {
+            $target->filesystem()->writeStream($target->getPath(), $stream);
+        } finally {
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+        }
+    }
+
+    protected function copyConversions(Media $target): void
+    {
+        $conversionsDir = $this->getDirectory().'/'.self::CONVERSIONS_DIR;
+
+        if (! $this->filesystem()->exists($conversionsDir)) {
+            return;
+        }
+
+        $sameDisk = $this->disk === $target->disk;
+        $sourceFs = $this->filesystem();
+        $targetFs = $target->filesystem();
+
+        foreach ($sourceFs->allFiles($conversionsDir) as $file) {
+            $relativePath = substr($file, strlen($conversionsDir) + 1);
+            $targetPath = $target->getDirectory().'/'.self::CONVERSIONS_DIR.'/'.$relativePath;
+
+            if ($sameDisk) {
+                $sourceFs->copy($file, $targetPath);
+
+                continue;
+            }
+
+            $stream = $sourceFs->readStream($file);
+
+            try {
+                $targetFs->writeStream($targetPath, $stream);
+            } finally {
+                if (is_resource($stream)) {
+                    fclose($stream);
+                }
+            }
+        }
+    }
+
+    protected function copyResponsiveVariants(Media $target): void
+    {
+        $responsiveDir = $this->getDirectory().'/'.self::RESPONSIVE_DIR;
+
+        if (! $this->filesystem()->exists($responsiveDir)) {
+            return;
+        }
+
+        $allFiles = $this->filesystem()->allFiles($responsiveDir);
+
+        foreach ($allFiles as $file) {
+            $relativePath = substr($file, strlen($responsiveDir) + 1);
+            $targetPath = $target->getDirectory().'/'.self::RESPONSIVE_DIR.'/'.$relativePath;
+
+            if ($this->disk === $target->disk) {
+                $this->filesystem()->copy($file, $targetPath);
+            } else {
+                $stream = $this->filesystem()->readStream($file);
+                $target->filesystem()->writeStream($targetPath, $stream);
+
+                if (is_resource($stream)) {
+                    fclose($stream);
+                }
+            }
+        }
     }
 }

--- a/src/Traits/HasMedia.php
+++ b/src/Traits/HasMedia.php
@@ -7,6 +7,7 @@ use Emaia\MediaMan\MediaChannel;
 use Emaia\MediaMan\Models\Media;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Throwable;
 
@@ -21,7 +22,7 @@ trait HasMedia
     protected array $mediaCache = [];
 
     /**
-     * Determine if there is any media in the specified group.
+     * Determine if there is any media in the specified channel.
      */
     public function hasMedia(string $channel = Media::DEFAULT_CHANNEL): bool
     {
@@ -29,7 +30,7 @@ trait HasMedia
     }
 
     /**
-     * Get all the media in the specified group.
+     * Get all the media in the specified channel.
      */
     public function getMedia(?string $channel = Media::DEFAULT_CHANNEL): Collection
     {
@@ -47,7 +48,11 @@ trait HasMedia
                 if ($channel === null) {
                     $this->mediaCache[$cacheKey] = $this->media()->get();
                 } else {
-                    $this->mediaCache[$cacheKey] = $this->media()->wherePivot('channel', $channel)->get();
+                    $table = config('mediaman.tables.mediables');
+                    $this->mediaCache[$cacheKey] = $this->media()
+                        ->wherePivot('channel', $channel)
+                        ->orderByRaw("({$table}.order_column IS NULL) ASC, {$table}.order_column ASC")
+                        ->get();
                 }
             }
         }
@@ -57,9 +62,12 @@ trait HasMedia
 
     public function media(): MorphToMany
     {
+        $table = config('mediaman.tables.mediables');
+
         return $this
-            ->morphToMany($this->mediaModel(), 'mediable', config('mediaman.tables.mediables'))
-            ->withPivot('channel');
+            ->morphToMany($this->mediaModel(), 'mediable', $table)
+            ->withPivot('channel', 'order_column')
+            ->orderByRaw("({$table}.order_column IS NULL) ASC, {$table}.order_column ASC");
     }
 
     /**
@@ -68,7 +76,7 @@ trait HasMedia
     public function getFirstMediaUrl(?string $channel = Media::DEFAULT_CHANNEL, string $conversion = ''): string
     {
         if (! $media = $this->getFirstMedia($channel)) {
-            return '';
+            return $this->getChannelFallbackUrl($channel, $conversion);
         }
 
         return $media->getUrl($conversion);
@@ -84,10 +92,13 @@ trait HasMedia
 
     /**
      * Attach media to the specified channel.
+     *
+     * If $order is null, new attaches receive the next sequential position
+     * in the channel. Pass an explicit integer to set the starting position.
      */
-    public function attachMedia($media, string $channel = Media::DEFAULT_CHANNEL, array $conversions = []): ?int
+    public function attachMedia($media, string $channel = Media::DEFAULT_CHANNEL, array $conversions = [], ?int $order = null): ?int
     {
-        $syncResult = $this->syncMedia($media, $channel, $conversions, false);
+        $syncResult = $this->syncMedia($media, $channel, $conversions, false, $order);
 
         $attachedCount = count($syncResult['attached'] ?? []);
 
@@ -97,10 +108,11 @@ trait HasMedia
     /**
      * Sync media to the specified channel.
      *
-     * This will remove the media that aren't in the provided list
-     * and add those which aren't already attached if $detaching is truthy.
+     * Removes media not in the provided list and attaches new ones (when
+     * $detaching is truthy). New attaches receive an order_column based on
+     * the channel's current max(order_column)+1, unless $startOrder is set.
      */
-    public function syncMedia(mixed $media, string $channel = Media::DEFAULT_CHANNEL, array $conversions = [], bool $detaching = true): ?array
+    public function syncMedia(mixed $media, string $channel = Media::DEFAULT_CHANNEL, array $conversions = [], bool $detaching = true, ?int $startOrder = null): ?array
     {
         $this->registerMediaChannels();
 
@@ -160,7 +172,17 @@ trait HasMedia
             }
 
             if (! empty($toAttach)) {
-                $this->media()->attach($toAttach, ['channel' => $channel]);
+                $baseOrder = $startOrder ?? $this->getNextOrder($channel);
+                $pivotData = [];
+
+                foreach ($toAttach as $index => $attachId) {
+                    $pivotData[$attachId] = [
+                        'channel' => $channel,
+                        'order_column' => $baseOrder + $index,
+                    ];
+                }
+
+                $this->media()->attach($pivotData);
                 $attached = $toAttach;
             }
 
@@ -178,6 +200,86 @@ trait HasMedia
     }
 
     /**
+     * Reorder media in the specified channel by the given array of ids.
+     * Positions are assigned 0..N-1 in the order of $ids.
+     *
+     * Throws InvalidArgumentException if any id is not currently attached
+     * to this model in the given channel.
+     */
+    public function setMediaOrder(array $ids, string $channel = Media::DEFAULT_CHANNEL): void
+    {
+        $table = config('mediaman.tables.mediables');
+        $morphType = $this->getMorphClass();
+
+        $attachedIds = DB::table($table)
+            ->where('mediable_type', $morphType)
+            ->where('mediable_id', $this->getKey())
+            ->where('channel', $channel)
+            ->pluck('media_id')
+            ->all();
+
+        $invalid = array_diff($ids, $attachedIds);
+
+        if (! empty($invalid)) {
+            throw new \InvalidArgumentException(
+                'Media ids not attached to this model in channel ['.$channel.']: '.implode(', ', $invalid)
+            );
+        }
+
+        DB::transaction(function () use ($ids, $channel, $table, $morphType) {
+            foreach ($ids as $index => $mediaId) {
+                DB::table($table)
+                    ->where('mediable_type', $morphType)
+                    ->where('mediable_id', $this->getKey())
+                    ->where('channel', $channel)
+                    ->where('media_id', $mediaId)
+                    ->update(['order_column' => $index]);
+            }
+        });
+
+        $this->clearMediaCache($channel);
+    }
+
+    protected function getChannelFallbackUrl(?string $channel, string $conversion): string
+    {
+        $mediaChannel = $this->getMediaChannel($channel ?? Media::DEFAULT_CHANNEL);
+
+        if ($mediaChannel === null) {
+            return '';
+        }
+
+        return $mediaChannel->getFallbackUrl($conversion !== '' ? $conversion : null);
+    }
+
+    protected function getChannelFallbackPath(?string $channel, string $conversion): string
+    {
+        $mediaChannel = $this->getMediaChannel($channel ?? Media::DEFAULT_CHANNEL);
+
+        if ($mediaChannel === null) {
+            return '';
+        }
+
+        return $mediaChannel->getFallbackPath($conversion !== '' ? $conversion : null);
+    }
+
+    /**
+     * Get the next sequential order_column value for a channel.
+     */
+    protected function getNextOrder(string $channel): int
+    {
+        $table = config('mediaman.tables.mediables');
+        $morphType = $this->getMorphClass();
+
+        $max = DB::table($table)
+            ->where('mediable_type', $morphType)
+            ->where('mediable_id', $this->getKey())
+            ->where('channel', $channel)
+            ->max('order_column');
+
+        return $max !== null ? (int) $max + 1 : 0;
+    }
+
+    /**
      * Register all the model's media channels.
      */
     public function registerMediaChannels(): void
@@ -186,9 +288,7 @@ trait HasMedia
     }
 
     /**
-     * Check if all media should be detached
-     *
-     * bool|null|empty-string|empty-array to detach all media
+     * Detach all media when given bool, null, empty string, or empty array.
      */
     protected function shouldDetachAll($media): bool
     {
@@ -213,7 +313,7 @@ trait HasMedia
     }
 
     /**
-     * Limpar cache de media para um channel específico ou todos.
+     * Clear cached media for a channel, or all channels when null.
      */
     protected function clearMediaCache(?string $channel = null): void
     {
@@ -241,7 +341,15 @@ trait HasMedia
             return [$media->getKey()];
         }
 
-        return (array) $media;
+        $ids = (array) $media;
+
+        return array_map(function ($id) {
+            if (is_object($id) && method_exists($id, 'getKey')) {
+                return $id->getKey();
+            }
+
+            return $id;
+        }, $ids);
     }
 
     /**
@@ -270,7 +378,7 @@ trait HasMedia
     public function getFirstMediaUrlWithFallback(?string $channel = Media::DEFAULT_CHANNEL, string $conversion = ''): string
     {
         if (! $media = $this->getFirstMedia($channel)) {
-            return '';
+            return $this->getChannelFallbackUrl($channel, $conversion);
         }
 
         return $media->getUrlWithFallback($conversion);
@@ -301,6 +409,18 @@ trait HasMedia
     }
 
     /**
+     * Get the absolute path of the first media item, or the channel fallback path.
+     */
+    public function getFirstMediaPath(?string $channel = Media::DEFAULT_CHANNEL, string $conversion = ''): string
+    {
+        if (! $media = $this->getFirstMedia($channel)) {
+            return $this->getChannelFallbackPath($channel, $conversion);
+        }
+
+        return $media->getFullPath($conversion);
+    }
+
+    /**
      * Get the last media item in the specified channel.
      */
     public function getLastMedia(?string $channel = Media::DEFAULT_CHANNEL)
@@ -314,7 +434,7 @@ trait HasMedia
     public function getLastMediaUrl(?string $channel = Media::DEFAULT_CHANNEL, string $conversion = ''): string
     {
         if (! $media = $this->getLastMedia($channel)) {
-            return '';
+            return $this->getChannelFallbackUrl($channel, $conversion);
         }
 
         return $media->getUrl($conversion);
@@ -326,7 +446,7 @@ trait HasMedia
     public function getLastMediaUrlWithFallback(?string $channel = Media::DEFAULT_CHANNEL, string $conversion = ''): string
     {
         if (! $media = $this->getLastMedia($channel)) {
-            return '';
+            return $this->getChannelFallbackUrl($channel, $conversion);
         }
 
         return $media->getUrlWithFallback($conversion);
@@ -357,9 +477,21 @@ trait HasMedia
     }
 
     /**
-     * Register a new media group.
+     * Get the absolute path of the last media item, or the channel fallback path.
      */
-    protected function addMediaChannel(string $name): MediaChannel
+    public function getLastMediaPath(?string $channel = Media::DEFAULT_CHANNEL, string $conversion = ''): string
+    {
+        if (! $media = $this->getLastMedia($channel)) {
+            return $this->getChannelFallbackPath($channel, $conversion);
+        }
+
+        return $media->getFullPath($conversion);
+    }
+
+    /**
+     * Register a new media channel.
+     */
+    public function addMediaChannel(string $name): MediaChannel
     {
         $channel = app(MediaChannel::class);
 

--- a/tests/Feature/OrderingFallbackCopyTest.php
+++ b/tests/Feature/OrderingFallbackCopyTest.php
@@ -1,0 +1,237 @@
+<?php
+
+use Emaia\MediaMan\MediaUploader;
+use Emaia\MediaMan\Models\Media;
+use Emaia\MediaMan\Tests\Models\Subject;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    $this->subject = Subject::create();
+});
+
+// ─── Ordering: attachMedia(..., $order) + pivot persistence ─────────
+
+it('persists the order argument from attachMedia in the pivot table', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('a.jpg'))->upload();
+
+    $this->subject->attachMedia($media, 'default', [], 5);
+
+    $pivot = $this->subject->media()->wherePivot('media_id', $media->id)->first()->pivot;
+
+    expect((int) $pivot->order_column)->toEqual(5);
+});
+
+it('auto-assigns sequential order when no order argument is given', function () {
+    $m1 = MediaUploader::source(UploadedFile::fake()->image('a.jpg'))->upload();
+    $m2 = MediaUploader::source(UploadedFile::fake()->image('b.jpg'))->upload();
+
+    $this->subject->attachMedia($m1);
+    $this->subject->attachMedia($m2);
+
+    $media = $this->subject->getMedia();
+
+    expect($media)->toHaveCount(2)
+        ->and((int) $media[0]->pivot->order_column)->toEqual(0)
+        ->and((int) $media[1]->pivot->order_column)->toEqual(1);
+});
+
+it('returns media ordered by order_column after individual attaches', function () {
+    $m1 = MediaUploader::source(UploadedFile::fake()->image('a.jpg'))->upload();
+    $m2 = MediaUploader::source(UploadedFile::fake()->image('b.jpg'))->upload();
+    $m3 = MediaUploader::source(UploadedFile::fake()->image('c.jpg'))->upload();
+
+    $this->subject->attachMedia($m1, 'default', [], 2);
+    $this->subject->attachMedia($m2, 'default', [], 0);
+    $this->subject->attachMedia($m3, 'default', [], 1);
+
+    $ids = $this->subject->getMedia()->pluck('id')->all();
+
+    expect($ids)->toEqual([$m2->id, $m3->id, $m1->id]);
+});
+
+it('batch attach with order argument uses it as starting offset', function () {
+    $m1 = MediaUploader::source(UploadedFile::fake()->image('a.jpg'))->upload();
+    $m2 = MediaUploader::source(UploadedFile::fake()->image('b.jpg'))->upload();
+
+    $this->subject->attachMedia([$m1, $m2], 'default', [], 10);
+
+    $orders = $this->subject->getMedia()->pluck('pivot.order_column')->map(fn ($o) => (int) $o)->all();
+
+    expect($orders)->toEqual([10, 11]);
+});
+
+it('setMediaOrder reorders media in a channel', function () {
+    $m1 = MediaUploader::source(UploadedFile::fake()->image('a.jpg'))->upload();
+    $m2 = MediaUploader::source(UploadedFile::fake()->image('b.jpg'))->upload();
+    $m3 = MediaUploader::source(UploadedFile::fake()->image('c.jpg'))->upload();
+
+    $this->subject->attachMedia([$m1, $m2, $m3]);
+
+    $this->subject->setMediaOrder([$m3->id, $m1->id, $m2->id]);
+
+    $ids = $this->subject->getMedia()->pluck('id')->all();
+
+    expect($ids)->toEqual([$m3->id, $m1->id, $m2->id]);
+});
+
+it('setMediaOrder throws when given an id not attached in the channel', function () {
+    $m1 = MediaUploader::source(UploadedFile::fake()->image('a.jpg'))->upload();
+    $m2 = MediaUploader::source(UploadedFile::fake()->image('b.jpg'))->upload();
+    $orphan = MediaUploader::source(UploadedFile::fake()->image('c.jpg'))->upload();
+
+    $this->subject->attachMedia([$m1, $m2]);
+
+    $this->subject->setMediaOrder([$m1->id, $orphan->id]);
+})->throws(InvalidArgumentException::class);
+
+it('setMediaOrder does not affect other channels', function () {
+    $fa = MediaUploader::source(UploadedFile::fake()->image('a.jpg'))->upload();
+    $fb = MediaUploader::source(UploadedFile::fake()->image('b.jpg'))->upload();
+    $ga = MediaUploader::source(UploadedFile::fake()->image('c.jpg'))->upload();
+
+    $this->subject->attachMedia([$fa, $fb], 'featured');
+    $this->subject->attachMedia($ga, 'gallery');
+
+    $this->subject->setMediaOrder([$fb->id, $fa->id], 'featured');
+
+    $fIds = $this->subject->getMedia('featured')->pluck('id')->all();
+    $gIds = $this->subject->getMedia('gallery')->pluck('id')->all();
+
+    expect($fIds)->toEqual([$fb->id, $fa->id])
+        ->and($gIds)->toEqual([$ga->id]);
+});
+
+// ─── Fallback URLs / Paths ──────────────────────────────────────────
+
+it('returns fallback URL when channel has no media', function () {
+    $this->subject->addMediaChannel('avatar')
+        ->useFallbackUrl('/img/default-avatar.png');
+
+    $url = $this->subject->getFirstMediaUrl('avatar');
+
+    expect($url)->toEqual('/img/default-avatar.png');
+});
+
+it('returns per-conversion fallback URL', function () {
+    $this->subject->addMediaChannel('avatar')
+        ->useFallbackUrl('/img/default-avatar.png')
+        ->useFallbackUrl('/img/thumb.png', 'thumb');
+
+    $url = $this->subject->getFirstMediaUrl('avatar', 'thumb');
+
+    expect($url)->toEqual('/img/thumb.png');
+});
+
+it('returns empty string when no fallback is set and no media', function () {
+    $url = $this->subject->getFirstMediaUrl('empty-channel');
+
+    expect($url)->toEqual('');
+});
+
+it('returns media URL instead of fallback when media exists', function () {
+    $this->subject->addMediaChannel('avatar')
+        ->useFallbackUrl('/img/default-avatar.png');
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('avatar.jpg'))->upload();
+    $this->subject->attachMedia($media, 'avatar');
+
+    $url = $this->subject->getFirstMediaUrl('avatar');
+
+    expect($url)->not->toEqual('/img/default-avatar.png');
+});
+
+it('getFirstMediaPath returns fallback path when channel empty', function () {
+    $this->subject->addMediaChannel('avatar')
+        ->useFallbackPath('/tmp/default-avatar.png');
+
+    $path = $this->subject->getFirstMediaPath('avatar');
+
+    expect($path)->toEqual('/tmp/default-avatar.png');
+});
+
+it('getLastMediaUrl uses fallback when channel empty', function () {
+    $this->subject->addMediaChannel('avatar')
+        ->useFallbackUrl('/img/last-avatar.png');
+
+    $url = $this->subject->getLastMediaUrl('avatar');
+
+    expect($url)->toEqual('/img/last-avatar.png');
+});
+
+it('getLastMediaUrlWithFallback uses channel fallback when empty', function () {
+    $this->subject->addMediaChannel('avatar')
+        ->useFallbackUrl('/img/any-avatar.png');
+
+    $url = $this->subject->getLastMediaUrlWithFallback('avatar', 'thumb');
+
+    expect($url)->toEqual('/img/any-avatar.png');
+});
+
+it('getLastMediaPath returns fallback path when channel empty', function () {
+    $this->subject->addMediaChannel('avatar')
+        ->useFallbackPath('/tmp/last.png');
+
+    $path = $this->subject->getLastMediaPath('avatar');
+
+    expect($path)->toEqual('/tmp/last.png');
+});
+
+// ─── Media::copy() ───────────────────────────────────────────────────
+
+it('Media::copy creates a new Media record with a new ID', function () {
+    $original = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $copy = $original->copy($this->subject);
+
+    expect($copy->id)->not->toEqual($original->id)
+        ->and($copy->name)->toEqual($original->name)
+        ->and($copy->file_name)->toEqual($original->file_name)
+        ->and(Storage::disk(self::DEFAULT_DISK)->exists($copy->getPath()))->toBeTrue();
+});
+
+it('Media::copy attaches the copy to the target model', function () {
+    $original = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $copy = $original->copy($this->subject, 'featured');
+
+    expect($this->subject->getMedia('featured'))->toHaveCount(1)
+        ->and($this->subject->getFirstMedia('featured')->id)->toEqual($copy->id);
+});
+
+it('Media::copy preserves the original file', function () {
+    $original = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $original->copy($this->subject);
+
+    expect(Storage::disk(self::DEFAULT_DISK)->exists($original->getPath()))->toBeTrue();
+});
+
+// ─── Media::attachTo() ───────────────────────────────────────────────
+
+it('Media::attachTo attaches to target without duplicating', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+    $otherSubject = Subject::create();
+
+    $media->attachTo($this->subject, 'gallery');
+
+    expect($this->subject->getMedia('gallery'))->toHaveCount(1)
+        ->and($this->subject->getFirstMedia('gallery')->id)->toEqual($media->id);
+});
+
+it('Media::attachTo can be chained', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $result = $media->attachTo($this->subject);
+
+    expect($result)->toBe($media);
+});
+
+it('Media::copy copies to a different disk via fallback', function () {
+    $original = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $copy = $original->copy($this->subject);
+
+    expect(Storage::disk(self::DEFAULT_DISK)->exists($copy->getPath()))->toBeTrue()
+        ->and($copy->disk)->toEqual(self::DEFAULT_DISK);
+});

--- a/tests/database/migrations/2021_02_11_000001_create_mediaman_tables.php
+++ b/tests/database/migrations/2021_02_11_000001_create_mediaman_tables.php
@@ -51,6 +51,7 @@ return new class extends Migration
             $table->unsignedBigInteger('mediable_id')->index();
             $table->string('mediable_type');
             $table->string('channel');
+            $table->integer('order_column')->nullable()->index();
 
             $table->foreign('media_id')
                 ->references('id')


### PR DESCRIPTION
## Summary

### Ordering
- New `order_column` column on `mediaman_mediables` (nullable, indexed)
- `HasMedia::attachMedia($media, $channel, $conversions, ?int $order = null)` — optional starting position; auto-assigns sequential via `max(order_column)+1` when null
- `HasMedia::syncMedia(..., ?int $startOrder = null)` — replaces the previous `bool $preserveOrder` parameter
- `HasMedia::setMediaOrder(array $ids, $channel)` — batch reorder in a DB transaction; throws `InvalidArgumentException` when an id is not currently attached in the channel
- `media()` and `getMedia()` order by `order_column` with NULLS LAST semantics via raw `ORDER BY (order_column IS NULL), order_column` (cross-DB)

### Fallback URLs / paths
- `MediaChannel::useFallbackUrl($url, ?conversion)` and `useFallbackPath($path, ?conversion)` — per-conversion override on top of a channel default
- `getFirstMediaUrl`, `getFirstMediaUrlWithFallback`, `getFirstMediaPath`, `getLastMediaUrl`, `getLastMediaUrlWithFallback`, `getLastMediaPath` all return the configured fallback when the channel has no media

### Copy / attachTo
- `Media::copy($target, $channel)` clones the Media record, copies the primary file, conversions, and responsive variants; rolls back the DB record if any file copy fails
- `Media::attachTo($target, $channel)` re-attaches the same Media without touching files (chainable, returns `$this`)
- New `InvalidCopyTarget` exception when target is not a `HasMedia` user

## BC notice

- **Schema:** existing installations must add `order_column` (`integer`, nullable, indexed) to `mediaman_mediables` via a custom migration before upgrading. Fresh installs get it automatically via the updated `create_mediaman_tables` stub.
- **`HasMedia::syncMedia` 5th parameter changed semantics:** was `bool $preserveOrder = false`, now `?int $startOrder = null`. Existing callers passing `true`/`false` will type-error. There were no public release candidates exposing the old signature.
- **`HasMedia::syncMedia` no longer leaves `order_column` as NULL:** new attaches are always assigned an order (auto-sequential or `$startOrder`-based). Pre-existing pivot rows with NULL are preserved as-is.
- **`media()` and `getMedia()` are now ordered by `order_column` with NULLS LAST semantics** via raw `ORDER BY (order_column IS NULL), order_column`. Rows pre-dating this release have NULL and now sort to the end. Code that relied on insertion order without an explicit `order_column` may see different orderings on read.
- **`HasMedia::addMediaChannel()` is now `public`** (was `protected`). PHP fatal-errors only if a subclass declared an override as `protected`; fix is to make the override `public`. Enables ad-hoc channel configuration (`$model->addMediaChannel('x')->useFallbackUrl(...)`) outside of `registerMediaChannels()`.

## Test plan

- [x] `composer test` — 503/503 (1 skip env-dependent)
- [x] `composer analyse` — clean
- [x] `vendor/bin/pint --test` — clean
- [ ] Manual smoke: `$subject->attachMedia($media, 'gallery', [], 5)` → pivot has `order_column = 5`
- [ ] Manual smoke: chain `attachMedia` without order — sequential 0, 1, 2
- [ ] Manual smoke: `setMediaOrder([3, 1, 2])` reorders without touching other channels
- [ ] Manual smoke: `setMediaOrder([999])` for a non-attached id → `InvalidArgumentException`
- [ ] Manual smoke: channel with `useFallbackUrl('/img/x.png')` returns it when no media
- [ ] Manual smoke: `$media->copy($otherSubject, 'featured')` → new id, file on disk, attached to subject
- [ ] Manual smoke: copy with failing target disk → DB record rolled back
- [ ] Manual smoke: `$media->attachTo($subject)` — chainable, no file ops