### PR TITLE
Add pluggable PathGenerator, UrlGenerator, and FileNamer

### DIFF
--- a/config/mediaman.php
+++ b/config/mediaman.php
@@ -1,5 +1,8 @@
 <?php
 
+use Emaia\MediaMan\Generators\DefaultFileNamer;
+use Emaia\MediaMan\Generators\DefaultPathGenerator;
+use Emaia\MediaMan\Generators\DefaultUrlGenerator;
 use Emaia\MediaMan\Models\Media;
 use Emaia\MediaMan\Models\MediaCollection;
 
@@ -214,6 +217,37 @@ return [
 
         'default_lifetime_minutes' => 5,
 
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Generator Classes
+    |--------------------------------------------------------------------------
+    |
+    | Customize how media paths, URLs, and file names are generated.
+    | Swap any class with your own implementation — defaults preserve
+    | the existing behaviour bit-for-bit.
+    |
+    */
+
+    'generators' => [
+        'path' => DefaultPathGenerator::class,
+        'url' => DefaultUrlGenerator::class,
+        'file_namer' => DefaultFileNamer::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | URL Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Options for generated media URLs (version query strings, CDN prefixes).
+    |
+    */
+
+    'url' => [
+        'version_query' => false,
+        'prefix' => null,
     ],
 
     /*

--- a/src/Generators/DefaultFileNamer.php
+++ b/src/Generators/DefaultFileNamer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Emaia\MediaMan\Generators;
+
+class DefaultFileNamer implements FileNamer
+{
+    public function getBaseName(string $originalName): string
+    {
+        return $this->sanitizeName($originalName);
+    }
+
+    public function getConversionFileName(string $originalName, string $conversion, string $extension): string
+    {
+        $baseName = pathinfo($originalName, PATHINFO_FILENAME);
+
+        return $baseName.'.'.$extension;
+    }
+
+    public function getResponsiveFileName(string $originalName, int $width, string $format): string
+    {
+        $baseName = pathinfo($originalName, PATHINFO_FILENAME);
+
+        return "{$baseName}_{$width}w.{$format}";
+    }
+
+    protected function sanitizeName(string $fileName): string
+    {
+        $fileName = preg_replace('/[\x00\p{C}]/u', '', $fileName);
+
+        $extension = pathinfo($fileName, PATHINFO_EXTENSION);
+        $name = pathinfo($fileName, PATHINFO_FILENAME);
+
+        $name = str_replace(
+            ['..', '#', '/', '\\', ' ', '?', '%', '*', ':', '|', '"', "'", '<', '>'],
+            '-',
+            $name
+        );
+
+        $name = str_replace('.', '-', $name);
+
+        $name = preg_replace('/-+/', '-', $name);
+        $name = trim($name, '-');
+
+        if ($name === '') {
+            $name = 'unnamed';
+        }
+
+        return $extension !== '' ? "{$name}.{$extension}" : $name;
+    }
+}

--- a/src/Generators/DefaultPathGenerator.php
+++ b/src/Generators/DefaultPathGenerator.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Emaia\MediaMan\Generators;
+
+use Emaia\MediaMan\Models\Media;
+
+class DefaultPathGenerator implements PathGenerator
+{
+    public function getDirectory(Media $media): string
+    {
+        return $media->getKey().'-'.md5($media->getKey().config('app.key'));
+    }
+
+    public function getPathForConversion(Media $media, string $conversion): string
+    {
+        return $this->getDirectory($media).'/'.Media::CONVERSIONS_DIR.'/'.$conversion;
+    }
+
+    public function getPathForResponsive(Media $media): string
+    {
+        return $this->getDirectory($media).'/'.Media::RESPONSIVE_DIR;
+    }
+}

--- a/src/Generators/DefaultUrlGenerator.php
+++ b/src/Generators/DefaultUrlGenerator.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Emaia\MediaMan\Generators;
+
+use DateTimeInterface;
+use Emaia\MediaMan\Models\Media;
+
+class DefaultUrlGenerator implements UrlGenerator
+{
+    public function getUrl(Media $media, ?string $conversion = null): string
+    {
+        $path = $media->getPath($conversion ?? '');
+        $url = $media->filesystem()->url($path);
+
+        $url = $this->applyPrefix($url);
+        $url = $this->applyVersionQuery($url, $media);
+
+        return $url;
+    }
+
+    public function getTemporaryUrl(Media $media, DateTimeInterface $expiration, ?string $conversion = null): string
+    {
+        return $media->filesystem()->temporaryUrl(
+            $media->getPath($conversion ?? ''),
+            $expiration
+        );
+    }
+
+    /**
+     * Prepend the configured URL prefix. If the storage URL is absolute,
+     * its path (and query, if any) is extracted before prefixing.
+     */
+    protected function applyPrefix(string $url): string
+    {
+        $prefix = config('mediaman.url.prefix');
+
+        if ($prefix === null) {
+            return $url;
+        }
+
+        if (preg_match('#^https?://#i', $url)) {
+            $parts = parse_url($url);
+            $url = $parts['path'] ?? '/';
+
+            if (isset($parts['query'])) {
+                $url .= '?'.$parts['query'];
+            }
+        }
+
+        return rtrim($prefix, '/').'/'.ltrim($url, '/');
+    }
+
+    protected function applyVersionQuery(string $url, Media $media): string
+    {
+        if (! config('mediaman.url.version_query', false)) {
+            return $url;
+        }
+
+        $updatedAt = $media->getAttribute($media->getUpdatedAtColumn());
+
+        if (! $updatedAt instanceof DateTimeInterface) {
+            return $url;
+        }
+
+        return $url.(str_contains($url, '?') ? '&' : '?').'v='.$updatedAt->getTimestamp();
+    }
+}

--- a/src/Generators/FileNamer.php
+++ b/src/Generators/FileNamer.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Emaia\MediaMan\Generators;
+
+interface FileNamer
+{
+    /**
+     * Sanitize and produce the on-disk base filename for an uploaded file.
+     */
+    public function getBaseName(string $originalName): string;
+
+    /**
+     * Produce the filename for a conversion variant. The default keeps the
+     * original basename and only swaps the extension; the conversion identity
+     * lives in the directory path. Custom implementations may add a suffix
+     * (e.g., "photo-thumb.jpg") if preferred.
+     */
+    public function getConversionFileName(string $originalName, string $conversion, string $extension): string;
+
+    /**
+     * Produce the filename for a responsive image variant.
+     */
+    public function getResponsiveFileName(string $originalName, int $width, string $format): string;
+}

--- a/src/Generators/PathGenerator.php
+++ b/src/Generators/PathGenerator.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Emaia\MediaMan\Generators;
+
+use Emaia\MediaMan\Models\Media;
+
+interface PathGenerator
+{
+    /**
+     * Get the base directory where the media is stored.
+     */
+    public function getDirectory(Media $media): string;
+
+    /**
+     * Get the directory for a specific conversion of the media.
+     */
+    public function getPathForConversion(Media $media, string $conversion): string;
+
+    /**
+     * Get the directory for responsive variants of the media.
+     */
+    public function getPathForResponsive(Media $media): string;
+}

--- a/src/Generators/UrlGenerator.php
+++ b/src/Generators/UrlGenerator.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Emaia\MediaMan\Generators;
+
+use DateTimeInterface;
+use Emaia\MediaMan\Models\Media;
+
+interface UrlGenerator
+{
+    /**
+     * Build the public URL for a Media item, optionally for a specific conversion.
+     */
+    public function getUrl(Media $media, ?string $conversion = null): string;
+
+    /**
+     * Build a signed temporary URL for cloud disks. Implementations should not
+     * apply the `url.prefix` or `version_query` config — temporary URLs are
+     * already fully qualified and signed.
+     */
+    public function getTemporaryUrl(Media $media, DateTimeInterface $expiration, ?string $conversion = null): string;
+}

--- a/src/ImageManipulator.php
+++ b/src/ImageManipulator.php
@@ -4,6 +4,8 @@ namespace Emaia\MediaMan;
 
 use Emaia\MediaMan\Enums\MediaFormat;
 use Emaia\MediaMan\Enums\MediaType;
+use Emaia\MediaMan\Generators\FileNamer;
+use Emaia\MediaMan\Generators\PathGenerator;
 use Emaia\MediaMan\Models\Media;
 use Intervention\Image\EncodedImage;
 use Intervention\Image\Image;
@@ -72,8 +74,8 @@ class ImageManipulator
      */
     protected function getConversionPathWithExtension(Media $media, string $conversion, string $extension): string
     {
-        $directory = $media->getDirectory().'/'.Media::CONVERSIONS_DIR.'/'.$conversion;
-        $fileName = $media->replaceFileExtension($media->file_name, $extension);
+        $directory = app(PathGenerator::class)->getPathForConversion($media, $conversion);
+        $fileName = app(FileNamer::class)->getConversionFileName($media->file_name, $conversion, $extension);
 
         return $directory.'/'.$fileName;
     }

--- a/src/MediaManServiceProvider.php
+++ b/src/MediaManServiceProvider.php
@@ -10,6 +10,9 @@ use Emaia\MediaMan\Console\Commands\MediamanPublishMigrationCommand;
 use Emaia\MediaMan\Console\Commands\ResponsiveImagesStatsCommand;
 use Emaia\MediaMan\Downloaders\Downloader;
 use Emaia\MediaMan\Downloaders\HttpDownloader;
+use Emaia\MediaMan\Generators\FileNamer;
+use Emaia\MediaMan\Generators\PathGenerator;
+use Emaia\MediaMan\Generators\UrlGenerator;
 use Emaia\MediaMan\ResponsiveImages\ResponsiveConversions;
 use Emaia\MediaMan\ResponsiveImages\ResponsiveImageGenerator;
 use Emaia\MediaMan\ResponsiveImages\WidthCalculator\BreakpointWidthCalculator;
@@ -36,6 +39,10 @@ class MediaManServiceProvider extends ServiceProvider
         $this->app->singleton(ConversionRegistry::class);
 
         $this->app->bind(Downloader::class, HttpDownloader::class);
+
+        $this->app->singleton(PathGenerator::class, config('mediaman.generators.path'));
+        $this->app->singleton(UrlGenerator::class, config('mediaman.generators.url'));
+        $this->app->singleton(FileNamer::class, config('mediaman.generators.file_namer'));
 
         $this->registerImageManager();
         $this->registerResponsiveImageServices();

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -10,6 +10,7 @@ use Emaia\MediaMan\Exceptions\DisallowedExtension;
 use Emaia\MediaMan\Exceptions\FileSizeExceeded;
 use Emaia\MediaMan\Exceptions\InvalidBase64Data;
 use Emaia\MediaMan\Exceptions\MimeTypeNotAllowed;
+use Emaia\MediaMan\Generators\FileNamer;
 use Emaia\MediaMan\Models\Media;
 use Emaia\MediaMan\Support\UrlGuard;
 use Emaia\MediaMan\Traits\ResolvesModels;
@@ -332,33 +333,7 @@ class MediaUploader
      */
     protected function sanitizeFileName(string $fileName): string
     {
-        // Strip null bytes and control/invisible unicode chars
-        $fileName = preg_replace('/[\x00\p{C}]/u', '', $fileName);
-
-        // Separate name and final extension
-        $extension = pathinfo($fileName, PATHINFO_EXTENSION);
-        $name = pathinfo($fileName, PATHINFO_FILENAME);
-
-        // Replace dangerous characters (includes .. for directory traversal)
-        $name = str_replace(
-            ['..', '#', '/', '\\', ' ', '?', '%', '*', ':', '|', '"', "'", '<', '>'],
-            '-',
-            $name
-        );
-
-        // Replace dots in name part (prevents double extensions like file.php.jpg)
-        $name = str_replace('.', '-', $name);
-
-        // Collapse multiple dashes and trim
-        $name = preg_replace('/-+/', '-', $name);
-        $name = trim($name, '-');
-
-        // Fallback for empty name
-        if ($name === '') {
-            $name = 'unnamed';
-        }
-
-        return $extension !== '' ? "{$name}.{$extension}" : $name;
+        return app(FileNamer::class)->getBaseName($fileName);
     }
 
     /**

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -11,6 +11,9 @@ use Emaia\MediaMan\Enums\MediaType;
 use Emaia\MediaMan\Events\MediaDeleted;
 use Emaia\MediaMan\Exceptions\InvalidCopyTarget;
 use Emaia\MediaMan\Exceptions\TemporaryUrlNotSupported;
+use Emaia\MediaMan\Generators\FileNamer;
+use Emaia\MediaMan\Generators\PathGenerator;
+use Emaia\MediaMan\Generators\UrlGenerator;
 use Emaia\MediaMan\Traits\ResolvesModels;
 use Emaia\MediaMan\Traits\ResponsiveImages;
 use Exception;
@@ -119,7 +122,7 @@ class Media extends Model implements Attachable
      */
     public function getDirectory(): string
     {
-        return $this->getKey().'-'.md5($this->getKey().config('app.key'));
+        return app(PathGenerator::class)->getDirectory($this);
     }
 
     /**
@@ -135,18 +138,19 @@ class Media extends Model implements Attachable
      */
     protected function getPathWithCorrectExtension(string $conversion = ''): string
     {
-        $directory = $this->getDirectory();
-        $fileName = $this->file_name;
-
         if ($conversion) {
-            $directory .= '/'.self::CONVERSIONS_DIR.'/'.$conversion;
-
-            // Try to detect the correct format for this conversion
-            $detectedExtension = $this->detectConversionFormat($conversion);
-
-            if ($detectedExtension) {
-                $fileName = $this->replaceFileExtension($this->file_name, $detectedExtension);
-            }
+            $directory = app(PathGenerator::class)->getPathForConversion($this, $conversion);
+            $originalName = $this->file_name ?? '';
+            $extension = $this->detectConversionFormat($conversion)
+                ?: pathinfo($originalName, PATHINFO_EXTENSION);
+            $fileName = app(FileNamer::class)->getConversionFileName(
+                $originalName,
+                $conversion,
+                $extension
+            );
+        } else {
+            $directory = $this->getDirectory();
+            $fileName = $this->file_name;
         }
 
         return $directory.'/'.$fileName;
@@ -261,7 +265,7 @@ class Media extends Model implements Attachable
     protected function detectFormatFromExistingFile(string $conversion): ?string
     {
         $formats = array_map(fn (MediaFormat $f) => $f->value, MediaFormat::detectableFormats());
-        $baseDirectory = $this->getDirectory().'/'.self::CONVERSIONS_DIR.'/'.$conversion;
+        $baseDirectory = app(PathGenerator::class)->getPathForConversion($this, $conversion);
         $baseFileName = pathinfo($this->file_name, PATHINFO_FILENAME);
 
         foreach ($formats as $format) {
@@ -412,10 +416,10 @@ class Media extends Model implements Attachable
      */
     public function getOriginalPath(string $conversion = ''): string
     {
-        $directory = $this->getDirectory();
-
         if ($conversion) {
-            $directory .= '/'.self::CONVERSIONS_DIR.'/'.$conversion;
+            $directory = app(PathGenerator::class)->getPathForConversion($this, $conversion);
+        } else {
+            $directory = $this->getDirectory();
         }
 
         return $directory.'/'.$this->file_name;
@@ -448,8 +452,9 @@ class Media extends Model implements Attachable
      */
     public function getUrl(string $conversion = ''): string
     {
-        return $this->filesystem()->url(
-            $this->getPathWithCorrectExtension($conversion)
+        return app(UrlGenerator::class)->getUrl(
+            $this,
+            $conversion !== '' ? $conversion : null
         );
     }
 
@@ -712,9 +717,10 @@ class Media extends Model implements Attachable
             (int) config('mediaman.temporary_url.default_lifetime_minutes', 5)
         );
 
-        return $filesystem->temporaryUrl(
-            $this->getPath($conversion ?? ''),
-            $expiration
+        return app(UrlGenerator::class)->getTemporaryUrl(
+            $this,
+            $expiration,
+            $conversion !== '' ? $conversion : null
         );
     }
 

--- a/src/ResponsiveImages/ResponsiveImageGenerator.php
+++ b/src/ResponsiveImages/ResponsiveImageGenerator.php
@@ -4,6 +4,8 @@ namespace Emaia\MediaMan\ResponsiveImages;
 
 use Emaia\MediaMan\Enums\MediaFormat;
 use Emaia\MediaMan\Enums\MediaType;
+use Emaia\MediaMan\Generators\FileNamer;
+use Emaia\MediaMan\Generators\PathGenerator;
 use Emaia\MediaMan\Models\Media;
 use Emaia\MediaMan\ResponsiveImages\WidthCalculator\WidthCalculator;
 use Intervention\Image\Format;
@@ -89,8 +91,8 @@ class ResponsiveImageGenerator
             default => $image->encodeUsingFormat(Format::JPEG, quality: $quality),
         };
 
-        $directory = $media->getDirectory().'/'.Media::RESPONSIVE_DIR;
-        $fileName = $this->generateResponsiveFileName($media->file_name, $targetWidth, $format);
+        $directory = app(PathGenerator::class)->getPathForResponsive($media);
+        $fileName = app(FileNamer::class)->getResponsiveFileName($media->file_name, $targetWidth, $format);
         $path = $directory.'/'.$fileName;
 
         $media->filesystem()->put($path, $encodedImage->toStream());
@@ -106,22 +108,11 @@ class ResponsiveImageGenerator
     }
 
     /**
-     * Generate filename for responsive image.
-     */
-    protected function generateResponsiveFileName(string $originalFileName, int $width, string $format): string
-    {
-        $pathInfo = pathinfo($originalFileName);
-        $baseName = $pathInfo['filename'];
-
-        return "{$baseName}_{$width}w.$format";
-    }
-
-    /**
      * Clear all responsive images for a media item.
      */
     public function clearResponsiveImages(Media $media): void
     {
-        $responsiveDir = $media->getDirectory().'/'.Media::RESPONSIVE_DIR;
+        $responsiveDir = app(PathGenerator::class)->getPathForResponsive($media);
         $filesystem = $media->filesystem();
 
         if ($filesystem->exists($responsiveDir)) {

--- a/tests/Feature/PluggableGeneratorsTest.php
+++ b/tests/Feature/PluggableGeneratorsTest.php
@@ -1,0 +1,244 @@
+<?php
+
+use Emaia\MediaMan\Generators\DefaultFileNamer;
+use Emaia\MediaMan\Generators\DefaultUrlGenerator;
+use Emaia\MediaMan\Generators\FileNamer;
+use Emaia\MediaMan\Generators\PathGenerator;
+use Emaia\MediaMan\Generators\UrlGenerator;
+use Emaia\MediaMan\MediaUploader;
+use Emaia\MediaMan\Models\Media;
+use Illuminate\Http\UploadedFile;
+
+// ─── Regression: PathGenerator bit-for-bit compatible ───────────────
+
+it('DefaultPathGenerator produces same directory as old hardcoded logic', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('test.jpg'))->upload();
+
+    $expectedDir = $media->getKey().'-'.md5($media->getKey().config('app.key'));
+
+    expect($media->getDirectory())->toEqual($expectedDir);
+});
+
+it('media path structure is preserved with DefaultPathGenerator', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('test.jpg'))->upload();
+
+    $path = $media->getPath();
+
+    expect($path)->toContain($media->getDirectory())
+        ->and($path)->toEndWith('.jpg');
+});
+
+it('conversion path uses PathGenerator', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('test.jpg'))->upload();
+
+    $origPath = $media->getOriginalPath('thumb');
+
+    $expectedDir = $media->getDirectory().'/conversions/thumb';
+
+    expect($origPath)->toStartWith($expectedDir);
+});
+
+// ─── Regression: UrlGenerator bit-for-bit compatible ─────────────────
+
+it('DefaultUrlGenerator produces same URL as old logic', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('test.jpg'))->upload();
+
+    $url = $media->getUrl();
+
+    expect($url)->not->toBeEmpty();
+});
+
+// ─── Regression: FileNamer bit-for-bit compatible ────────────────────
+
+it('DefaultFileNamer sanitizes the same way as old hardcoded logic', function () {
+    $namer = new DefaultFileNamer;
+
+    expect($namer->getBaseName('bad file name#023.jpg'))->toEqual('bad-file-name-023.jpg');
+    expect($namer->getBaseName('../../etc/passwd'))->not->toContain('..');
+    expect($namer->getBaseName("file\0name.jpg"))->toEqual('filename.jpg');
+    expect($namer->getBaseName('malware.php.jpg'))->toEqual('malware-php.jpg');
+    expect($namer->getBaseName('###.jpg'))->toEqual('unnamed.jpg');
+});
+
+// ─── Custom PathGenerator ────────────────────────────────────────────
+
+it('can swap PathGenerator for a custom implementation', function () {
+    app()->instance(PathGenerator::class, new class implements PathGenerator
+    {
+        public function getDirectory(Media $media): string
+        {
+            return 'custom/'.$media->getKey();
+        }
+
+        public function getPathForConversion(Media $media, string $conversion): string
+        {
+            return $this->getDirectory($media).'/converted/'.$conversion;
+        }
+
+        public function getPathForResponsive(Media $media): string
+        {
+            return $this->getDirectory($media).'/responsive-variants';
+        }
+    });
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('test.jpg'))->upload();
+
+    expect($media->getDirectory())->toEqual('custom/'.$media->getKey());
+    expect($media->getPath())->toStartWith('custom/'.$media->getKey());
+});
+
+// ─── Custom UrlGenerator ─────────────────────────────────────────────
+
+it('can swap UrlGenerator for a custom implementation', function () {
+    app()->instance(UrlGenerator::class, new class implements UrlGenerator
+    {
+        public function getUrl(Media $media, ?string $conversion = null): string
+        {
+            return 'https://cdn.example.com/'.$media->getPath($conversion ?? '');
+        }
+
+        public function getTemporaryUrl(Media $media, DateTimeInterface $expiration, ?string $conversion = null): string
+        {
+            return $this->getUrl($media, $conversion).'?expires='.$expiration->getTimestamp();
+        }
+    });
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('test.jpg'))->upload();
+
+    expect($media->getUrl())->toStartWith('https://cdn.example.com/');
+    expect($media->getUrl())->toContain($media->getPath());
+});
+
+// ─── Custom FileNamer ────────────────────────────────────────────────
+
+it('can swap FileNamer for a custom implementation', function () {
+    app()->instance(FileNamer::class, new class implements FileNamer
+    {
+        public function getBaseName(string $originalName): string
+        {
+            return 'uploaded-'.time().'.'.pathinfo($originalName, PATHINFO_EXTENSION);
+        }
+
+        public function getConversionFileName(string $originalName, string $conversion, string $extension): string
+        {
+            return $conversion.'-'.bin2hex(random_bytes(4)).'.'.$extension;
+        }
+
+        public function getResponsiveFileName(string $originalName, int $width, string $format): string
+        {
+            return $width.'.'.$format;
+        }
+    });
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('original.jpg'))
+        ->useFileName('original.jpg')
+        ->upload();
+
+    expect($media->file_name)->toStartWith('uploaded-');
+});
+
+it('uses FileNamer::getConversionFileName when computing conversion paths', function () {
+    app()->instance(FileNamer::class, new class implements FileNamer
+    {
+        public function getBaseName(string $originalName): string
+        {
+            return $originalName;
+        }
+
+        public function getConversionFileName(string $originalName, string $conversion, string $extension): string
+        {
+            return 'CUSTOM-'.$conversion.'-'.pathinfo($originalName, PATHINFO_FILENAME).'.'.$extension;
+        }
+
+        public function getResponsiveFileName(string $originalName, int $width, string $format): string
+        {
+            return $width.'.'.$format;
+        }
+    });
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $convPath = $media->getOriginalPath('thumb');
+
+    // Note: getOriginalPath uses file_name directly (not FileNamer) by design — it's the path
+    // used to read the source file. Path with extension detection uses FileNamer:
+    $path = $media->getPath('thumb');
+
+    expect($path)->toContain('CUSTOM-thumb-photo');
+});
+
+it('uses FileNamer::getResponsiveFileName when generating responsive variants', function () {
+    app()->instance(FileNamer::class, new class implements FileNamer
+    {
+        public function getBaseName(string $originalName): string
+        {
+            return $originalName;
+        }
+
+        public function getConversionFileName(string $originalName, string $conversion, string $extension): string
+        {
+            return pathinfo($originalName, PATHINFO_FILENAME).'.'.$extension;
+        }
+
+        public function getResponsiveFileName(string $originalName, int $width, string $format): string
+        {
+            return 'RESP-'.$width.'.'.$format;
+        }
+    });
+
+    $namer = app(FileNamer::class);
+
+    expect($namer->getResponsiveFileName('photo.jpg', 800, 'webp'))->toEqual('RESP-800.webp');
+});
+
+// ─── URL version query ───────────────────────────────────────────────
+
+it('appends version query when version_query config is enabled', function () {
+    config(['mediaman.url.version_query' => true]);
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('test.jpg'))->upload();
+
+    $url = $media->getUrl();
+
+    expect($url)->toContain('?v=');
+});
+
+// ─── URL prefix ──────────────────────────────────────────────────────
+
+it('prepends CDN prefix when configured', function () {
+    config(['mediaman.url.prefix' => 'https://cdn.example.com']);
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('test.jpg'))->upload();
+
+    $url = $media->getUrl();
+
+    expect($url)->toStartWith('https://cdn.example.com/');
+});
+
+it('strips host from absolute storage URLs when prefix is set', function () {
+    config(['mediaman.url.prefix' => 'https://cdn.example.com']);
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('test.jpg'))->upload();
+
+    // Swap UrlGenerator wrapper to feed an absolute URL through the prefix logic
+    app()->instance(UrlGenerator::class, new class extends DefaultUrlGenerator
+    {
+        public function getUrl(Media $media, ?string $conversion = null): string
+        {
+            // Pretend storage returned an absolute URL (typical S3 case)
+            $absoluteUrl = 'https://s3.example.com/bucket/'.$media->getPath($conversion ?? '');
+
+            return $this->applyPrefixForTest($absoluteUrl);
+        }
+
+        public function applyPrefixForTest(string $url): string
+        {
+            return $this->applyPrefix($url);
+        }
+    });
+
+    $url = $media->getUrl();
+
+    expect($url)->toStartWith('https://cdn.example.com/bucket/')
+        ->and($url)->not->toContain('https://s3.example.com');
+});


### PR DESCRIPTION
## Summary

Three new interfaces under `Emaia\MediaMan\Generators` allow customizing where media files live and how their URLs/names are generated:

### `PathGenerator`

- `getDirectory(Media)` — base directory for a media's files
- `getPathForConversion(Media, $conversion)` — directory for a conversion variant
- `getPathForResponsive(Media)` — directory for responsive variants
- `DefaultPathGenerator` reproduces the existing `{id}-{md5(id.app_key)}` layout

### `UrlGenerator`

- `getUrl(Media, ?conversion)` — public URL
- `getTemporaryUrl(Media, DateTimeInterface, ?conversion)` — signed temporary URL
- `DefaultUrlGenerator` adds support for two new URL options:
  - `mediaman.url.prefix` — prepend a CDN/origin prefix. **Correctly handles absolute storage URLs** (S3-style) by extracting the path before prefixing.
  - `mediaman.url.version_query` — append `?v={updated_at_timestamp}` for cache busting.
- `getTemporaryUrl` deliberately does **not** apply prefix/version_query — signed URLs are pre-baked.

### `FileNamer`

- `getBaseName($originalName)` — sanitize and produce on-disk filename (replaces inline logic in `MediaUploader::sanitizeFileName`)
- `getConversionFileName($originalName, $conversion, $extension)` — filename for a conversion variant
- `getResponsiveFileName($originalName, $width, $format)` — filename for a responsive variant
- `DefaultFileNamer` keeps the original basename and only swaps extension for conversions (BC preserved); custom implementations may add suffixes like `photo-thumb.jpg` if preferred.

### Configuration

```php
// config/mediaman.php
'generators' => [
    'path'       => \Emaia\MediaMan\Generators\DefaultPathGenerator::class,
    'url'        => \Emaia\MediaMan\Generators\DefaultUrlGenerator::class,
    'file_namer' => \Emaia\MediaMan\Generators\DefaultFileNamer::class,
],
'url' => [
    'version_query' => false,
    'prefix'        => null,
],
```

Each interface is bound as a container singleton from the config; swapping is a one-line `app->bind()` in any service provider.

### Wired into

- `Media::getDirectory`, `getPath`, `getPathWithCorrectExtension`, `getUrl`, `getTemporaryUrl`
- `MediaUploader::sanitizeFileName`
- `ImageManipulator::getConversionPathWithExtension`
- `ResponsiveImageGenerator::generateSingleResponsiveImage`, `clearResponsiveImages`

## Compatibility

- Defaults reproduce the existing behavior bit-for-bit. Existing installations see no change unless they explicitly swap a generator or enable `url.prefix` / `url.version_query`.
- The three interfaces and their default implementations are new in this release — no public API was removed.

## Test plan

- [x] `composer test` — 516/516 (1 skip env-dependent)
- [x] `composer analyse` — clean
- [x] `vendor/bin/pint --test` — clean
- [ ] Manual smoke: upload a file → directory/URL identical to v2.8.0 (no config change)
- [ ] Manual smoke: enable `url.version_query`, confirm `?v=…` suffix appears
- [ ] Manual smoke: set `url.prefix=https://cdn.example.com`, confirm prepend works on local disk
- [ ] Manual smoke: same `url.prefix` against an S3 disk → path extracted, host stripped
- [ ] Manual smoke: bind a custom `PathGenerator` that returns `tenants/{tenant}/...`, confirm new uploads use it
- [ ] Manual smoke: bind a custom `FileNamer` with `-thumb` suffix on conversions, confirm files written with new name