### PR TITLE
Native LQIP, driver auto-detect, disk fallback, recipes, CI/release tooling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!--
+Two or three bullets describing what changes and why. Keep the framing on
+intent, not on which lines moved.
+-->
+
+## Test plan
+
+- [ ] `composer test`
+- [ ] `composer analyse`
+- [ ] `vendor/bin/pint --test`
+- [ ] Manual smoke (when the change isn't fully covered by tests — describe the steps)
+
+## Documentation
+
+- [ ] `CHANGELOG.md` updated under `[Unreleased]`
+- [ ] Relevant `docs/*.md` updated
+- [ ] README index / link table updated if a new doc was added
+
+## Notes / fixes (optional)
+
+<!--
+Behavior changes, BC concerns, or anything reviewers should pay extra
+attention to. Remove the section if there's nothing here.
+-->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           - laravel: 13.*
             testbench: 11.*
 
-    name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }} / ${{ matrix.dependency-versions }}
+    name: Test / PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }} / ${{ matrix.dependency-versions }}
 
     steps:
       - name: Checkout
@@ -42,3 +42,46 @@ jobs:
 
       - name: Run tests
         run: vendor/bin/pest
+
+  analyse:
+    name: PHPStan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, imagick
+          tools: composer:v2
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse
+
+  lint:
+    name: Pint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          tools: composer:v2
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run Pint
+        run: vendor/bin/pint --test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract release notes from CHANGELOG.md
+        id: notes
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Extracting notes for version $VERSION from CHANGELOG.md"
+
+          # Print every line under the matching ## [VERSION] heading until the
+          # next ## [ heading. Fails if no matching section is found.
+          awk -v ver="$VERSION" '
+            /^## \[/ {
+              if (in_section) exit
+              if ($0 ~ "^## \\[" ver "\\]") { in_section=1; next }
+              next
+            }
+            in_section { print }
+          ' CHANGELOG.md > notes.md
+
+          if [ ! -s notes.md ]; then
+            echo "::error::No CHANGELOG.md section found for version $VERSION."
+            echo "Add a '## [$VERSION] — YYYY-MM-DD' heading before tagging."
+            exit 1
+          fi
+
+          echo "--- Extracted release notes ---"
+          cat notes.md
+          echo "-------------------------------"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          body_path: notes.md
+          fail_on_unmatched_files: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to `emaia/laravel-mediaman` will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- `mediaman.driver` default is now `null` and **auto-detected** at boot — `imagick` when ext-imagick is loaded, `gd` otherwise. Previously hardcoded to `imagick`, which threw `InvalidArgumentException` at runtime on servers without ext-imagick. Existing installations that set `MEDIAMAN_DRIVER` explicitly are unaffected.
+- `mediaman.disk` default is now `null` and **falls back to** `config('filesystems.default')`. Previously hardcoded to `'public'`. Existing installations that set the value explicitly are unaffected; in practice Laravel's default disk is also `'public'` in fresh apps, so behavior matches for the common case.
+
+### Tooling
+
+- CI now runs `phpstan` and `pint --test` jobs in parallel with the test matrix. Previously only pest ran on PRs.
+- New `.github/workflows/release.yml` creates a GitHub Release automatically when a `v*` tag is pushed, extracting the matching section from `CHANGELOG.md`. The manual `gh release create --notes-file …` step is no longer needed.
+- New `.github/PULL_REQUEST_TEMPLATE.md` prompts contributors to update the CHANGELOG and relevant docs.
+
+### Added
+
+- **LQIP placeholder is now a native (opt-in) feature.** Enable via `MEDIAMAN_PLACEHOLDER_ENABLED=true` to have image uploads generate a tiny blurred JPEG (~2 KB) stored as a base64 data URI in `custom_properties.placeholder`. New methods on `Media`:
+  - `getPlaceholder(): ?string` — returns the data URI or null
+  - `getUrlOrPlaceholder(string $conversion = ''): string` — returns conversion URL when the file exists, falls back to placeholder, then to the original URL. Useful right after upload when queued conversions have not run yet.
+  - `getPictureHtml()` and `getSimpleImgHtml()` automatically inject the placeholder as a CSS background-image on the inner `<img>`. Opt out per call with `['placeholder' => false]`. Silent when no placeholder exists.
+  - Configurable via `mediaman.placeholder` (enabled, width, blur, quality). Default off, matching the package convention of opt-in feature toggles (mirrors `responsive_images.auto_generate`). Only fires for `image/*` uploads; failures fall back to `null` without breaking the upload.
+- `docs/recipes.md` — seven pluggable patterns for needs that MediaMan deliberately doesn't ship (image optimization, PDF/video thumbnails, SVG rasterization, ZIP downloads, multi-file uploads, string/stream uploads). Each recipe consumes the package's events + `custom_properties` + `PathGenerator` to slot cleanly into the existing pipeline.
+
+## [2.10.0] — 2026-06-17
+
 ### Added
 
 - `mediaman:publish` artisan command — publishes config and migration in one step. Individual `mediaman:publish-config` and `mediaman:publish-migration` remain for selective use.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ $post->attachMedia($media, 'featured-image-channel');
 | [**Security**](docs/security.md)                   | Disallowed extensions, SSRF guard, orphan cleanup                                 |
 | [**Events**](docs/events.md)                       | The four package events                                                           |
 | [**Artisan commands**](docs/commands.md)           | Publish assets, orphan cleanup, responsive image generation and stats             |
+| [**Recipes**](docs/recipes.md)                     | PDF/video thumbnails, image optimization, ZIP downloads, multi-file uploads       |
 | [**API reference**](docs/api.md)                   | Public surface by class/trait                                                     |
 
 Release history: [CHANGELOG.md](CHANGELOG.md).
@@ -59,8 +60,7 @@ Release history: [CHANGELOG.md](CHANGELOG.md).
 
 ```bash
 composer require emaia/laravel-mediaman
-php artisan mediaman:publish-config
-php artisan mediaman:publish-migration
+php artisan mediaman:publish
 php artisan storage:link
 php artisan migrate
 ```

--- a/config/mediaman.php
+++ b/config/mediaman.php
@@ -18,18 +18,20 @@ return [
     */
 
     /*
-    | The default disk where files should be uploaded.
+    | The default disk where files should be uploaded. When null, falls
+    | back to Laravel's default filesystem disk (config/filesystems.php).
     */
 
-    'disk' => 'public',
+    'disk' => env('MEDIAMAN_DISK'),
 
     /*
     | Image processing driver for intervention/image.
     | Supported: "imagick" (ImageMagick) or "gd" (GD Library).
-    | Make sure the corresponding PHP extension is installed.
+    | When null, auto-detected — prefers imagick when ext-imagick is loaded,
+    | falls back to gd otherwise. Set explicitly when you need a guarantee.
     */
 
-    'driver' => env('MEDIAMAN_DRIVER', 'imagick'),
+    'driver' => env('MEDIAMAN_DRIVER'),
 
     /*
     | The queue used for image conversions and responsive image generation.
@@ -182,6 +184,20 @@ return [
         // Optional CDN/origin prefix (e.g. 'https://cdn.example.com').
         // Absolute storage URLs (S3-style) are stripped before prefixing.
         'prefix' => null,
+    ],
+
+    /*
+    | Low-quality image placeholder (LQIP). Generated synchronously on
+    | upload for images, stored as a base64 data URI in custom_properties.
+    | Useful as a fallback while queued conversions catch up or as a CSS
+    | background-image for lazy-loaded media. Adds ~50ms per image upload.
+    */
+
+    'placeholder' => [
+        'enabled' => env('MEDIAMAN_PLACEHOLDER_ENABLED', false),
+        'width' => 32,    // px
+        'blur' => 20,
+        'quality' => 40,  // JPEG quality (1-100)
     ],
 
     /*

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,94 +24,96 @@ Public surface of the package, organized by class/trait. Each entry links back t
 
 ### Static / scope methods
 
-| Signature | Description |
-|---|---|
-| `Media::find($id)` | Standard Eloquent. |
-| `Media::findByName(string $name)` | Lookup by `name`. |
-| `Media::destroy($id\|array)` | Delete and clean up files. |
+| Signature                         | Description                |
+|-----------------------------------|----------------------------|
+| `Media::find($id)`                | Standard Eloquent.         |
+| `Media::findByName(string $name)` | Lookup by `name`.          |
+| `Media::destroy($id\|array)`      | Delete and clean up files. |
 
 ### URL & path
 
-| Signature | Description |
-|---|---|
-| `getUrl(string $conversion = ''): string` | Public URL (with `url.prefix` and `url.version_query` if configured). |
-| `getUrlWithFallback(string $conversion = ''): string` | Conversion URL or the original if missing. |
-| `getConversionUrl(string $conversion): ?string` | Conversion URL or `null` if missing. |
-| `getTemporaryUrl(?DateTimeInterface $expiration = null, ?string $conversion = null): string` | Signed URL on cloud disks. Throws `TemporaryUrlNotSupported` otherwise. |
-| `getPath(string $conversion = ''): string` | Path on disk (with extension detection). |
-| `getOriginalPath(string $conversion = ''): string` | Path on disk using `file_name` as-is. |
-| `getFullPath(string $conversion = ''): string` | Absolute path on disk. |
-| `getDirectory(): string` | Base directory of this media. |
+| Signature                                                                                    | Description                                                                                                                                                                   |
+|----------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `getUrl(string $conversion = ''): string`                                                    | Public URL (with `url.prefix` and `url.version_query` if configured).                                                                                                         |
+| `getUrlWithFallback(string $conversion = ''): string`                                        | Conversion URL or the original if missing.                                                                                                                                    |
+| `getUrlOrPlaceholder(string $conversion = ''): string`                                       | Conversion URL when the file exists, otherwise the LQIP placeholder data URI, otherwise the original URL. Useful right after upload when queued conversions have not run yet. |
+| `getConversionUrl(string $conversion): ?string`                                              | Conversion URL or `null` if missing.                                                                                                                                          |
+| `getPlaceholder(): ?string`                                                                  | LQIP placeholder data URI generated at upload time, or `null` if none was generated.                                                                                          |
+| `getTemporaryUrl(?DateTimeInterface $expiration = null, ?string $conversion = null): string` | Signed URL on cloud disks. Throws `TemporaryUrlNotSupported` otherwise.                                                                                                       |
+| `getPath(string $conversion = ''): string`                                                   | Path on disk (with extension detection).                                                                                                                                      |
+| `getOriginalPath(string $conversion = ''): string`                                           | Path on disk using `file_name` as-is.                                                                                                                                         |
+| `getFullPath(string $conversion = ''): string`                                               | Absolute path on disk.                                                                                                                                                        |
+| `getDirectory(): string`                                                                     | Base directory of this media.                                                                                                                                                 |
 
 ### Conversions & responsive
 
-| Signature | Description |
-|---|---|
-| `hasConversion(string $conversion): bool` | Conversion file exists. |
-| `generateResponsiveImages(array $options = []): void` | Generate responsive variants. |
-| `hasResponsiveImages(): bool` | Any responsive variants exist. |
-| `getResponsiveImages(): Collection` | Collection of variant descriptors. |
-| `getResponsiveUrl(?int $width = null, ?string $format = null): string` | URL of the best (or specified) variant. |
-| `getResponsiveImageForWidth(int $width, ?string $format = null): ?array` | Variant descriptor for a width. |
-| `getResponsiveImagesByFormat(string $format): Collection` | Variants in one format. |
-| `getResponsiveImagesByFormatGrouped(): array` | Variants keyed by format. |
-| `getAvailableResponsiveFormats(): array` | Formats present (e.g. `['avif','webp']`). |
-| `getBestResponsiveFormat(): ?string` | `avif` > `webp` > `jpg` > `png`. |
-| `getSrcset(?string $format = null): string` | srcset string. |
-| `getPictureHtml(array $attributes = [], ?string $sizes = null): string` | `<picture>` element. |
-| `getSimpleImgHtml(array $attributes = []): string` | Plain `<img>` element. |
-| `getImageWidth(): ?int` | Original width in px. |
-| `getImageHeight(): ?int` | Original height in px. |
-| `clearResponsiveImages(): void` | Remove variant files and metadata. |
+| Signature                                                                | Description                               |
+|--------------------------------------------------------------------------|-------------------------------------------|
+| `hasConversion(string $conversion): bool`                                | Conversion file exists.                   |
+| `generateResponsiveImages(array $options = []): void`                    | Generate responsive variants.             |
+| `hasResponsiveImages(): bool`                                            | Any responsive variants exist.            |
+| `getResponsiveImages(): Collection`                                      | Collection of variant descriptors.        |
+| `getResponsiveUrl(?int $width = null, ?string $format = null): string`   | URL of the best (or specified) variant.   |
+| `getResponsiveImageForWidth(int $width, ?string $format = null): ?array` | Variant descriptor for a width.           |
+| `getResponsiveImagesByFormat(string $format): Collection`                | Variants in one format.                   |
+| `getResponsiveImagesByFormatGrouped(): array`                            | Variants keyed by format.                 |
+| `getAvailableResponsiveFormats(): array`                                 | Formats present (e.g. `['avif','webp']`). |
+| `getBestResponsiveFormat(): ?string`                                     | `avif` > `webp` > `jpg` > `png`.          |
+| `getSrcset(?string $format = null): string`                              | srcset string.                            |
+| `getPictureHtml(array $attributes = [], ?string $sizes = null): string`  | `<picture>` element.                      |
+| `getSimpleImgHtml(array $attributes = []): string`                       | Plain `<img>` element.                    |
+| `getImageWidth(): ?int`                                                  | Original width in px.                     |
+| `getImageHeight(): ?int`                                                 | Original height in px.                    |
+| `clearResponsiveImages(): void`                                          | Remove variant files and metadata.        |
 
 ### HTTP responses & mail
 
-| Signature | Description |
-|---|---|
-| `toResponse(?string $conversion = null): StreamedResponse` | Download response. |
-| `toInlineResponse(?string $conversion = null): StreamedResponse` | Inline response. |
-| `getStream(?string $conversion = null)` | Read stream resource. Caller closes. |
-| `mailAttachment(?string $conversion = null): Attachment` | Build a `Illuminate\Mail\Attachment`. |
-| `toMailAttachment(): Attachment` | Attachable contract — original file. |
+| Signature                                                        | Description                           |
+|------------------------------------------------------------------|---------------------------------------|
+| `toResponse(?string $conversion = null): StreamedResponse`       | Download response.                    |
+| `toInlineResponse(?string $conversion = null): StreamedResponse` | Inline response.                      |
+| `getStream(?string $conversion = null)`                          | Read stream resource. Caller closes.  |
+| `mailAttachment(?string $conversion = null): Attachment`         | Build a `Illuminate\Mail\Attachment`. |
+| `toMailAttachment(): Attachment`                                 | Attachable contract — original file.  |
 
 ### Custom properties
 
-| Signature | Description |
-|---|---|
-| `hasCustomProperty(string $key): bool` | |
+| Signature                                                | Description            |
+|----------------------------------------------------------|------------------------|
+| `hasCustomProperty(string $key): bool`                   |                        |
 | `getCustomProperty(string $key, $default = null): mixed` | Supports dot notation. |
-| `setCustomProperty(string $key, $value): self` | Save afterwards. |
-| `forgetCustomProperty(string $key): self` | Save afterwards. |
+| `setCustomProperty(string $key, $value): self`           | Save afterwards.       |
+| `forgetCustomProperty(string $key): self`                | Save afterwards.       |
 
 ### Cross-model operations
 
-| Signature | Description |
-|---|---|
-| `copy(object $target, string $channel = 'default'): Media` | Clone record + files; attach copy to target. |
+| Signature                                                     | Description                                              |
+|---------------------------------------------------------------|----------------------------------------------------------|
+| `copy(object $target, string $channel = 'default'): Media`    | Clone record + files; attach copy to target.             |
 | `attachTo(object $target, string $channel = 'default'): self` | Re-attach existing Media to another model (no file ops). |
 
 ### Attribute helpers
 
-| Signature | Description |
-|---|---|
+| Signature                      | Description                |
+|--------------------------------|----------------------------|
 | `isOfType(string $type): bool` | e.g. `'image'`, `'video'`. |
 
 ### Relationships
 
-| Signature | Description |
-|---|---|
-| `collections(): BelongsToMany` | Many-to-many with `MediaCollection`. |
-| `attachCollections($collections): ?int` | Mirror of `MediaCollection::attachMedia`. Accepts Media or collection inputs by id/name/instance. |
-| `detachCollections($collections): ?int` | Mirror of `MediaCollection::detachMedia`. Pass empty/null/bool to detach from all. |
-| `syncCollections($collections, bool $detaching = true): array` | Mirror of `MediaCollection::syncMedia`. Returns `['attached','detached','updated']`. |
+| Signature                                                      | Description                                                                                       |
+|----------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| `collections(): BelongsToMany`                                 | Many-to-many with `MediaCollection`.                                                              |
+| `attachCollections($collections): ?int`                        | Mirror of `MediaCollection::attachMedia`. Accepts Media or collection inputs by id/name/instance. |
+| `detachCollections($collections): ?int`                        | Mirror of `MediaCollection::detachMedia`. Pass empty/null/bool to detach from all.                |
+| `syncCollections($collections, bool $detaching = true): array` | Mirror of `MediaCollection::syncMedia`. Returns `['attached','detached','updated']`.              |
 
 ### Constants
 
-| Name | Value | Use |
-|---|---|---|
-| `DEFAULT_CHANNEL` | `'default'` | Default value for channel parameters. |
-| `CONVERSIONS_DIR` | `'conversions'` | Subdirectory holding conversions. |
-| `RESPONSIVE_DIR` | `'responsive'` | Subdirectory holding responsive variants. |
+| Name              | Value           | Use                                       |
+|-------------------|-----------------|-------------------------------------------|
+| `DEFAULT_CHANNEL` | `'default'`     | Default value for channel parameters.     |
+| `CONVERSIONS_DIR` | `'conversions'` | Subdirectory holding conversions.         |
+| `RESPONSIVE_DIR`  | `'responsive'`  | Subdirectory holding responsive variants. |
 
 ---
 
@@ -121,46 +123,46 @@ Public surface of the package, organized by class/trait. Each entry links back t
 
 ### Static
 
-| Signature | Description |
-|---|---|
-| `MediaCollection::create(array $attrs)` | Standard Eloquent. |
+| Signature                                                                   | Description                                 |
+|-----------------------------------------------------------------------------|---------------------------------------------|
+| `MediaCollection::create(array $attrs)`                                     | Standard Eloquent.                          |
 | `MediaCollection::findByName(string\|array $names, array $columns = ['*'])` | One model for string, Collection for array. |
 
 ### Fluent configuration
 
-| Signature | Description |
-|---|---|
-| `singleFile(): self` | Shortcut for `onlyKeepLatest(1)`. |
-| `onlyKeepLatest(int $count): self` | Cap items; auto-prune oldest on overflow. |
+| Signature                              | Description                                                                   |
+|----------------------------------------|-------------------------------------------------------------------------------|
+| `singleFile(): self`                   | Shortcut for `onlyKeepLatest(1)`.                                             |
+| `onlyKeepLatest(int $count): self`     | Cap items; auto-prune oldest on overflow.                                     |
 | `acceptsMimeTypes(array $types): self` | MIME whitelist; supports wildcards (`image/*`). Empty/null = accept anything. |
 
 > Setters mutate in memory only — call `->save()` to persist.
 
 ### Validation & prune
 
-| Signature | Description |
-|---|---|
+| Signature                           | Description                                             |
+|-------------------------------------|---------------------------------------------------------|
 | `validateMedia(Media $media): void` | Throws `MediaNotAcceptedByCollection` on MIME mismatch. |
-| `enforceMaxItems(): void` | Detach oldest media down to `max_items`. |
+| `enforceMaxItems(): void`           | Detach oldest media down to `max_items`.                |
 
 ### Pivot operations
 
-| Signature | Description |
-|---|---|
-| `media(): BelongsToMany` | Media in this collection. |
-| `attachMedia($media): ?int` | Accepts Media, id, name, or iterable of those. |
-| `detachMedia($media): ?int` | Same input shapes. Pass empty/null/bool to detach all. |
-| `syncMedia($media, bool $detaching = true): ?array` | Replaces the set. |
+| Signature                                           | Description                                            |
+|-----------------------------------------------------|--------------------------------------------------------|
+| `media(): BelongsToMany`                            | Media in this collection.                              |
+| `attachMedia($media): ?int`                         | Accepts Media, id, name, or iterable of those.         |
+| `detachMedia($media): ?int`                         | Same input shapes. Pass empty/null/bool to detach all. |
+| `syncMedia($media, bool $detaching = true): ?array` | Replaces the set.                                      |
 
 ### Attributes
 
-| Field | Description |
-|---|---|
-| `name` (string) | |
-| `max_items` (int, nullable) | Auto-prune cap. |
-| `allowed_mime_types` (json, nullable) | MIME whitelist. |
-| `fallback_url` (string, nullable) | Reserved (not currently wired). |
-| `fallback_path` (string, nullable) | Reserved (not currently wired). |
+| Field                                 | Description                     |
+|---------------------------------------|---------------------------------|
+| `name` (string)                       |                                 |
+| `max_items` (int, nullable)           | Auto-prune cap.                 |
+| `allowed_mime_types` (json, nullable) | MIME whitelist.                 |
+| `fallback_url` (string, nullable)     | Reserved (not currently wired). |
+| `fallback_path` (string, nullable)    | Reserved (not currently wired). |
 
 ---
 
@@ -170,34 +172,34 @@ Public surface of the package, organized by class/trait. Each entry links back t
 
 ### Entry points
 
-| Signature | Description |
-|---|---|
-| `MediaUploader::source(UploadedFile $file): self` | Standard form-upload entry. |
-| `MediaUploader::fromRequest(string $key = 'file', ?Request $request = null): self` | Convenience for pulling a single file off the current request. Resolves the request from the container when not passed. Throws `InvalidArgumentException` when missing or multi-file. |
-| `MediaUploader::fromDisk(string $path, string $disk): self` | Import from any Laravel filesystem disk. |
-| `MediaUploader::fromBase64(string $data, string $filename, ?string $name = null): self` | Raw base64 or data URI. |
-| `MediaUploader::fromUrl(string $url): self` | SSRF-guarded remote download. Requires ext-curl. |
+| Signature                                                                               | Description                                                                                                                                                                           |
+|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `MediaUploader::source(UploadedFile $file): self`                                       | Standard form-upload entry.                                                                                                                                                           |
+| `MediaUploader::fromRequest(string $key = 'file', ?Request $request = null): self`      | Convenience for pulling a single file off the current request. Resolves the request from the container when not passed. Throws `InvalidArgumentException` when missing or multi-file. |
+| `MediaUploader::fromDisk(string $path, string $disk): self`                             | Import from any Laravel filesystem disk.                                                                                                                                              |
+| `MediaUploader::fromBase64(string $data, string $filename, ?string $name = null): self` | Raw base64 or data URI.                                                                                                                                                               |
+| `MediaUploader::fromUrl(string $url): self`                                             | SSRF-guarded remote download. Requires ext-curl.                                                                                                                                      |
 
 ### Fluent setters
 
-| Signature | Description |
-|---|---|
-| `useName(string)` / `setName` | Display name. |
-| `useFileName(string)` / `setFileName` | On-disk filename (sanitized via `FileNamer`). |
-| `useCollection(string)` / `toCollection` / `setCollection` | Bundle into collection (created on demand). |
-| `useDisk(string)` / `toDisk` / `setDisk` | Target disk. |
-| `withCustomProperties(array)` / `useCustomProperties` | Extra metadata stored as JSON. |
-| `allowMimeTypes(array)` | Per-upload MIME whitelist (overrides global). |
-| `maxFileSize(int $bytes)` | Per-upload size cap; `0` disables. |
-| `generateResponsive(array $options = [])` | Trigger responsive generation. |
-| `withBreakpoints(array)` | Responsive widths. |
-| `withFormats(array)` | Responsive output formats. |
-| `withQuality(int)` | Responsive quality. |
+| Signature                                                  | Description                                   |
+|------------------------------------------------------------|-----------------------------------------------|
+| `useName(string)` / `setName`                              | Display name.                                 |
+| `useFileName(string)` / `setFileName`                      | On-disk filename (sanitized via `FileNamer`). |
+| `useCollection(string)` / `toCollection` / `setCollection` | Bundle into collection (created on demand).   |
+| `useDisk(string)` / `toDisk` / `setDisk`                   | Target disk.                                  |
+| `withCustomProperties(array)` / `useCustomProperties`      | Extra metadata stored as JSON.                |
+| `allowMimeTypes(array)`                                    | Per-upload MIME whitelist (overrides global). |
+| `maxFileSize(int $bytes)`                                  | Per-upload size cap; `0` disables.            |
+| `generateResponsive(array $options = [])`                  | Trigger responsive generation.                |
+| `withBreakpoints(array)`                                   | Responsive widths.                            |
+| `withFormats(array)`                                       | Responsive output formats.                    |
+| `withQuality(int)`                                         | Responsive quality.                           |
 
 ### Terminal
 
-| Signature | Description |
-|---|---|
+| Signature         | Description                                                             |
+|-------------------|-------------------------------------------------------------------------|
 | `upload(): Media` | Persist record, write file, attach to collection, emit `MediaUploaded`. |
 
 ---
@@ -208,51 +210,51 @@ Public surface of the package, organized by class/trait. Each entry links back t
 
 ### Relationship
 
-| Signature | Description |
-|---|---|
+| Signature              | Description                             |
+|------------------------|-----------------------------------------|
 | `media(): MorphToMany` | Polymorphic many-to-many with ordering. |
 
 ### Existence / retrieval
 
-| Signature | Description |
-|---|---|
-| `hasMedia(string $channel = 'default'): bool` | |
-| `getMedia(?string $channel = 'default'): Collection` | Ordered by `order_column` (NULLS LAST). `null` channel returns all. |
-| `getFirstMedia(?string $channel = 'default'): ?Media` | |
-| `getLastMedia(?string $channel = 'default'): ?Media` | |
-| `getMediaChannel(string $name): ?MediaChannel` | Returns the configured channel object. |
+| Signature                                             | Description                                                         |
+|-------------------------------------------------------|---------------------------------------------------------------------|
+| `hasMedia(string $channel = 'default'): bool`         |                                                                     |
+| `getMedia(?string $channel = 'default'): Collection`  | Ordered by `order_column` (NULLS LAST). `null` channel returns all. |
+| `getFirstMedia(?string $channel = 'default'): ?Media` |                                                                     |
+| `getLastMedia(?string $channel = 'default'): ?Media`  |                                                                     |
+| `getMediaChannel(string $name): ?MediaChannel`        | Returns the configured channel object.                              |
 
 ### URL & path helpers
 
-| Signature | Description |
-|---|---|
-| `getFirstMediaUrl(?string $channel = 'default', string $conversion = ''): string` | Falls back to channel fallback URL when empty. |
-| `getFirstMediaUrlWithFallback(?string $channel = 'default', string $conversion = ''): string` | |
-| `getFirstMediaConversionUrl(?string $channel = 'default', string $conversion = ''): ?string` | |
-| `hasMediaConversion(?string $channel = 'default', string $conversion = ''): bool` | |
-| `getFirstMediaPath(?string $channel = 'default', string $conversion = ''): string` | |
-| `getLastMediaUrl(?string $channel = 'default', string $conversion = ''): string` | |
-| `getLastMediaUrlWithFallback(?string $channel = 'default', string $conversion = ''): string` | |
-| `getLastMediaConversionUrl(?string $channel = 'default', string $conversion = ''): ?string` | |
-| `hasLastMediaConversion(?string $channel = 'default', string $conversion = ''): bool` | |
-| `getLastMediaPath(?string $channel = 'default', string $conversion = ''): string` | |
+| Signature                                                                                     | Description                                    |
+|-----------------------------------------------------------------------------------------------|------------------------------------------------|
+| `getFirstMediaUrl(?string $channel = 'default', string $conversion = ''): string`             | Falls back to channel fallback URL when empty. |
+| `getFirstMediaUrlWithFallback(?string $channel = 'default', string $conversion = ''): string` |                                                |
+| `getFirstMediaConversionUrl(?string $channel = 'default', string $conversion = ''): ?string`  |                                                |
+| `hasMediaConversion(?string $channel = 'default', string $conversion = ''): bool`             |                                                |
+| `getFirstMediaPath(?string $channel = 'default', string $conversion = ''): string`            |                                                |
+| `getLastMediaUrl(?string $channel = 'default', string $conversion = ''): string`              |                                                |
+| `getLastMediaUrlWithFallback(?string $channel = 'default', string $conversion = ''): string`  |                                                |
+| `getLastMediaConversionUrl(?string $channel = 'default', string $conversion = ''): ?string`   |                                                |
+| `hasLastMediaConversion(?string $channel = 'default', string $conversion = ''): bool`         |                                                |
+| `getLastMediaPath(?string $channel = 'default', string $conversion = ''): string`             |                                                |
 
 ### Mutations
 
-| Signature | Description |
-|---|---|
-| `attachMedia($media, string $channel = 'default', array $conversions = [], ?int $order = null): ?int` | Count attached or null. |
-| `syncMedia($media, string $channel = 'default', array $conversions = [], bool $detaching = true, ?int $startOrder = null): ?array` | `['attached','detached','updated']`. |
-| `detachMedia($media = null): ?int` | Detach specific media (or all when `null`). |
-| `clearMediaChannel(string $channel = 'default'): void` | Detach all in a channel. |
-| `setMediaOrder(array $ids, string $channel = 'default'): void` | Reorder positions in a transaction. Throws `InvalidArgumentException` if any id isn't attached. |
+| Signature                                                                                                                          | Description                                                                                     |
+|------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| `attachMedia($media, string $channel = 'default', array $conversions = [], ?int $order = null): ?int`                              | Count attached or null.                                                                         |
+| `syncMedia($media, string $channel = 'default', array $conversions = [], bool $detaching = true, ?int $startOrder = null): ?array` | `['attached','detached','updated']`.                                                            |
+| `detachMedia($media = null): ?int`                                                                                                 | Detach specific media (or all when `null`).                                                     |
+| `clearMediaChannel(string $channel = 'default'): void`                                                                             | Detach all in a channel.                                                                        |
+| `setMediaOrder(array $ids, string $channel = 'default'): void`                                                                     | Reorder positions in a transaction. Throws `InvalidArgumentException` if any id isn't attached. |
 
 ### Channel registration
 
-| Signature | Description |
-|---|---|
-| `registerMediaChannels(): void` | Override on your model to declare channels. Called lazily. |
-| `addMediaChannel(string $name): MediaChannel` | Register a channel. Public — can be called ad-hoc too. |
+| Signature                                     | Description                                                |
+|-----------------------------------------------|------------------------------------------------------------|
+| `registerMediaChannels(): void`               | Override on your model to declare channels. Called lazily. |
+| `addMediaChannel(string $name): MediaChannel` | Register a channel. Public — can be called ad-hoc too.     |
 
 ---
 
@@ -260,15 +262,15 @@ Public surface of the package, organized by class/trait. Each entry links back t
 
 `Emaia\MediaMan\MediaChannel` — declared via `HasMedia::addMediaChannel()`.
 
-| Signature | Description |
-|---|---|
-| `performConversions(string ...$conversions): self` | Conversions to run when media is attached. |
-| `hasConversions(): bool` | |
-| `getConversions(): array` | |
-| `useFallbackUrl(string $url, ?string $conversion = null): self` | Default URL when channel is empty (or per-conversion override). |
-| `useFallbackPath(string $path, ?string $conversion = null): self` | Default absolute path when channel is empty. |
-| `getFallbackUrl(?string $conversion = null): string` | |
-| `getFallbackPath(?string $conversion = null): string` | |
+| Signature                                                         | Description                                                     |
+|-------------------------------------------------------------------|-----------------------------------------------------------------|
+| `performConversions(string ...$conversions): self`                | Conversions to run when media is attached.                      |
+| `hasConversions(): bool`                                          |                                                                 |
+| `getConversions(): array`                                         |                                                                 |
+| `useFallbackUrl(string $url, ?string $conversion = null): self`   | Default URL when channel is empty (or per-conversion override). |
+| `useFallbackPath(string $path, ?string $conversion = null): self` | Default absolute path when channel is empty.                    |
+| `getFallbackUrl(?string $conversion = null): string`              |                                                                 |
+| `getFallbackPath(?string $conversion = null): string`             |                                                                 |
 
 ---
 
@@ -347,9 +349,9 @@ Default: `HttpDownloader` — Laravel HTTP client + Guzzle, with `CURLOPT_RESOLV
 
 ### `Emaia\MediaMan\Support\UrlGuard`
 
-| Signature | Description |
-|---|---|
-| `UrlGuard::check(string $url): void` | Throws `UrlNotAllowed` for blocked URLs. |
+| Signature                                                                       | Description                                                        |
+|---------------------------------------------------------------------------------|--------------------------------------------------------------------|
+| `UrlGuard::check(string $url): void`                                            | Throws `UrlNotAllowed` for blocked URLs.                           |
 | `UrlGuard::resolve(string $url): array{host: string, port: int, ips: string[]}` | Validates and returns resolved IPs for DNS-rebinding-safe fetches. |
 
 See [Security → SSRF protection](security.md#ssrf-protection-for-remote-urls).
@@ -358,11 +360,11 @@ See [Security → SSRF protection](security.md#ssrf-protection-for-remote-urls).
 
 ## Events
 
-| Class | When |
-|---|---|
-| `Emaia\MediaMan\Events\MediaUploaded` | Right after `MediaUploader::upload()`. |
-| `Emaia\MediaMan\Events\MediaDeleted` | Right after `Media::delete()`. |
-| `Emaia\MediaMan\Events\ConversionCompleted` | At the end of the conversion queued job. |
+| Class                                             | When                                              |
+|---------------------------------------------------|---------------------------------------------------|
+| `Emaia\MediaMan\Events\MediaUploaded`             | Right after `MediaUploader::upload()`.            |
+| `Emaia\MediaMan\Events\MediaDeleted`              | Right after `Media::delete()`.                    |
+| `Emaia\MediaMan\Events\ConversionCompleted`       | At the end of the conversion queued job.          |
 | `Emaia\MediaMan\Events\ResponsiveImagesGenerated` | At the end of the responsive variants queued job. |
 
 See [Events](events.md).
@@ -373,22 +375,22 @@ See [Events](events.md).
 
 All exceptions live under `Emaia\MediaMan\Exceptions`.
 
-| Class | Source |
-|---|---|
-| `DisallowedExtension` | Upload of a blocked extension. |
-| `FileSizeExceeded` | File too large (per-upload or pre-decode). |
-| `MimeTypeNotAllowed` | MIME not in the configured whitelist. |
-| `InvalidBase64Data` | Malformed base64 or data URI in `fromBase64()`. |
-| `UrlNotAllowed` | URL rejected by `UrlGuard` (scheme, host, or resolved IP). |
-| `MediaNotAcceptedByCollection` | Collection-level MIME rejection. |
-| `TemporaryUrlNotSupported` | Disk doesn't support `temporaryUrl()`. |
-| `InvalidCopyTarget` | Target of `Media::copy()` or `attachTo()` doesn't use `HasMedia`. |
-| `InvalidConversion` | Conversion not registered. |
+| Class                          | Source                                                            |
+|--------------------------------|-------------------------------------------------------------------|
+| `DisallowedExtension`          | Upload of a blocked extension.                                    |
+| `FileSizeExceeded`             | File too large (per-upload or pre-decode).                        |
+| `MimeTypeNotAllowed`           | MIME not in the configured whitelist.                             |
+| `InvalidBase64Data`            | Malformed base64 or data URI in `fromBase64()`.                   |
+| `UrlNotAllowed`                | URL rejected by `UrlGuard` (scheme, host, or resolved IP).        |
+| `MediaNotAcceptedByCollection` | Collection-level MIME rejection.                                  |
+| `TemporaryUrlNotSupported`     | Disk doesn't support `temporaryUrl()`.                            |
+| `InvalidCopyTarget`            | Target of `Media::copy()` or `attachTo()` doesn't use `HasMedia`. |
+| `InvalidConversion`            | Conversion not registered.                                        |
 
 ---
 
 ## Facades
 
-| Facade | Backs |
-|---|---|
+| Facade                              | Backs                                                                           |
+|-------------------------------------|---------------------------------------------------------------------------------|
 | `Emaia\MediaMan\Facades\Conversion` | `Emaia\MediaMan\ConversionRegistry` — `Conversion::register('name', $closure)`. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ The config file is organized in four blocks: essentials, validation/security def
 - [Base64 uploads](#base64-uploads)
 - [Temporary URLs](#temporary-urls)
 - [URL generation](#url-generation)
+- [Placeholder](#placeholder)
 - [Responsive images](#responsive-images)
 
 **Customization**
@@ -33,7 +34,7 @@ The config file is organized in four blocks: essentials, validation/security def
 
 ## Storage disk
 
-By default media is written to Laravel's default filesystem disk. To dedicate a disk to MediaMan:
+`config('mediaman.disk')` falls back to `config('filesystems.default')` when null — set it explicitly to dedicate a separate disk to MediaMan, or leave it null to inherit Laravel's default. To wire up a separate disk:
 
 ```php
 // config/filesystems.php
@@ -66,18 +67,18 @@ MediaMan supports all of Laravel's storage drivers (Local, S3, SFTP, FTP, Dropbo
 
 ## Image driver
 
-MediaMan uses [intervention/image](https://github.com/Intervention/image) under the hood. Pick the PHP image library:
+MediaMan uses [intervention/image](https://github.com/Intervention/image) under the hood. The driver is **auto-detected** at boot — `imagick` when the PHP extension is loaded, otherwise `gd`. Set the config (or env) explicitly to force one:
 
 ```php
-'driver' => env('MEDIAMAN_DRIVER', 'imagick'), // or 'gd'
+'driver' => env('MEDIAMAN_DRIVER'), // null = auto-detect, 'imagick', or 'gd'
 ```
 
-| Driver    | PHP extension | Notes                                             |
-|-----------|---------------|---------------------------------------------------|
-| `imagick` | ext-imagick   | Default. Higher quality, full color-space support |
-| `gd`      | ext-gd        | Lighter, bundled in most PHP installations        |
+| Driver    | PHP extension | Notes                                                 |
+|-----------|---------------|-------------------------------------------------------|
+| `imagick` | ext-imagick   | Higher quality, full color-space support. Preferred. |
+| `gd`      | ext-gd        | Lighter, bundled in most PHP installations.          |
 
-An invalid value throws `InvalidArgumentException` at runtime.
+An invalid explicit value throws `InvalidArgumentException` at runtime.
 
 ## Queue
 
@@ -176,6 +177,25 @@ Apply a CDN prefix and/or cache-busting query string to all generated URLs (see 
 ```
 
 For absolute storage URLs (S3-style), the prefix correctly strips scheme+host before reapplying. Temporary signed URLs are **not** prefixed or version-tagged.
+
+## Placeholder
+
+Low-quality image placeholder (LQIP) — a tiny blurred JPEG generated synchronously on image upload, stored as a base64 data URI in `custom_properties.placeholder`. See [Media → Placeholder](media.md#placeholder-for-pending-conversions) for usage.
+
+**Opt-in by default.** Set `enabled=true` (or `MEDIAMAN_PLACEHOLDER_ENABLED=true`) to turn it on:
+
+```php
+'placeholder' => [
+    'enabled' => env('MEDIAMAN_PLACEHOLDER_ENABLED', false),
+    'width'   => 32,  // px
+    'blur'    => 20,
+    'quality' => 40,  // JPEG quality (1-100)
+],
+```
+
+When on, adds ~50 ms per image upload and ~2 KB to `custom_properties`. Generation only fires for `image/*` MIME types; failures (corrupt image, unsupported format) fall back to `null` without breaking the upload.
+
+When off, `Media::getPlaceholder()` returns `null`, `getUrlOrPlaceholder()` behaves like `getUrl()`, and `getPictureHtml()`/`getSimpleImgHtml()` skip the background-image injection silently.
 
 ## Responsive images
 

--- a/docs/media.md
+++ b/docs/media.md
@@ -6,6 +6,7 @@
 - [Attributes](#attributes)
 - [URL and path methods](#url-and-path-methods)
 - [HTTP responses](#http-responses)
+- [Placeholder for pending conversions](#placeholder-for-pending-conversions)
 - [Mail attachments](#mail-attachments)
 - [Custom properties](#custom-properties)
 - [Update](#update)
@@ -86,6 +87,42 @@ try {
 ```
 
 Default expiration via `temporary_url.default_lifetime_minutes` (5 min). Signed temporary URLs do **not** apply the `url.prefix` or `version_query` config.
+
+## Placeholder for pending conversions
+
+When the LQIP feature is enabled, MediaMan generates a tiny blurred JPEG (~2 KB) on image upload and stores it as a base64 data URI in `custom_properties.placeholder`. This is the LQIP (Low-Quality Image Placeholder) pattern — useful in two scenarios:
+
+- **Right after upload**, before the queued conversion job has finished, the conversion file doesn't exist yet on disk. Calling `getUrl('thumb')` would return a path to a missing file.
+- **Lazy-loaded galleries**, where you want a fast-rendering preview while the real image downloads.
+
+The feature is **opt-in** — enable it via [`placeholder` config](configuration.md#placeholder) or `MEDIAMAN_PLACEHOLDER_ENABLED=true`. Generated only for image uploads (`mime_type` starting with `image/`).
+
+```php
+$media->getPlaceholder();                 // 'data:image/jpeg;base64,...' or null
+
+// Return the placeholder when the conversion isn't on disk yet, otherwise the URL:
+$media->getUrlOrPlaceholder('thumb');
+```
+
+Manual rendering example:
+
+```blade
+<img
+    src="{{ $media->getUrlOrPlaceholder('thumb') }}"
+    style="background-image: url('{{ $media->getPlaceholder() }}'); background-size: cover;"
+    loading="lazy"
+    alt="{{ $media->name }}"
+>
+```
+
+`getPictureHtml()` and `getSimpleImgHtml()` already do this for you — the placeholder is injected as a CSS background-image on the `<img>` when one was generated. Opt out per call with `['placeholder' => false]`:
+
+```php
+echo $media->getPictureHtml();                          // includes background blur
+echo $media->getPictureHtml(['placeholder' => false]);  // skip the blur
+```
+
+See [Responsive images → Placeholder integration](responsive-images.md#placeholder-integration).
 
 ## Mail attachments
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,357 @@
+# Recipes
+
+[← Back to README](../README.md)
+
+- [Image optimization](#image-optimization)
+- [PDF first-page thumbnail](#pdf-first-page-thumbnail)
+- [Video thumbnail](#video-thumbnail)
+- [SVG to PNG fallback](#svg-to-png-fallback)
+- [ZIP download of multiple media](#zip-download-of-multiple-media)
+- [Multi-file form upload](#multi-file-form-upload)
+- [String or stream upload](#string-or-stream-upload)
+
+Common needs that MediaMan deliberately doesn't ship out-of-the-box — here's how to bolt them onto the existing event/queue/custom-properties flow.
+
+Most recipes follow the same shape:
+
+1. Listen to a MediaMan event (`MediaUploaded`, `ConversionCompleted`, `ResponsiveImagesGenerated`).
+2. Dispatch a queued job that runs a third-party library.
+3. Write any generated files into the Media's directory via `PathGenerator` (so paths remain pluggable).
+4. Persist metadata in `custom_properties`.
+
+---
+
+## Image optimization
+
+**Use case:** Run jpegoptim / pngquant / cwebp / avifenc against uploaded images and their conversions to shrink file sizes without changing the pipeline.
+
+**Approach:** Pair the package with [`spatie/image-optimizer`](https://github.com/spatie/image-optimizer), which wraps the CLI tools. Trigger it from `MediaUploaded` (originals) and `ConversionCompleted` (variants).
+
+```bash
+composer require spatie/image-optimizer
+# install the underlying binaries on your servers (jpegoptim, optipng, pngquant, cwebp, avifenc)
+```
+
+```php
+use Emaia\MediaMan\Events\ConversionCompleted;
+use Emaia\MediaMan\Events\MediaUploaded;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Spatie\ImageOptimizer\OptimizerChainFactory;
+
+class OptimizeUploadedImage implements ShouldQueue
+{
+    use Queueable;
+
+    public function handleMediaUploaded(MediaUploaded $event): void
+    {
+        $media = $event->media;
+
+        if (! $media->isOfType('image')) {
+            return;
+        }
+
+        $this->optimize($media, $media->getPath());
+    }
+
+    public function handleConversionCompleted(ConversionCompleted $event): void
+    {
+        $media = $event->media;
+
+        foreach ($event->conversions as $conversion) {
+            $this->optimize($media, $media->getPath($conversion));
+        }
+    }
+
+    private function optimize($media, string $path): void
+    {
+        $disk = $media->filesystem();
+
+        // Pull to tmp, optimize in place, push back.
+        $tmp = tempnam(sys_get_temp_dir(), 'opt_');
+        file_put_contents($tmp, $disk->get($path));
+
+        OptimizerChainFactory::create()->optimize($tmp);
+
+        $disk->put($path, file_get_contents($tmp));
+        @unlink($tmp);
+    }
+}
+```
+
+Register both methods in `EventServiceProvider`:
+
+```php
+protected $listen = [
+    MediaUploaded::class       => [[OptimizeUploadedImage::class, 'handleMediaUploaded']],
+    ConversionCompleted::class => [[OptimizeUploadedImage::class, 'handleConversionCompleted']],
+];
+```
+
+**Trade-offs:** Requires CLI binaries on each server (or in your container image). Cloud disks pay one read + write per file. For massive batches, schedule with rate-limiting.
+
+---
+
+## PDF first-page thumbnail
+
+**Use case:** Show a preview image for uploaded PDFs.
+
+**Approach:** Listen to `MediaUploaded`, render page 1 with `spatie/pdf-to-image` (Imagick + Ghostscript), write the result as a sibling file under the Media's directory, and reference it via `custom_properties`.
+
+```bash
+composer require spatie/pdf-to-image
+# Ghostscript must be installed on the server.
+```
+
+```php
+use Emaia\MediaMan\Events\MediaUploaded;
+use Emaia\MediaMan\Generators\PathGenerator;
+use Spatie\PdfToImage\Pdf;
+
+class GeneratePdfThumbnail implements ShouldQueue
+{
+    public function handle(MediaUploaded $event): void
+    {
+        $media = $event->media;
+
+        if ($media->mime_type !== 'application/pdf') {
+            return;
+        }
+
+        $disk = $media->filesystem();
+        $tmpPdf = tempnam(sys_get_temp_dir(), 'pdf_').'.pdf';
+        $tmpJpg = tempnam(sys_get_temp_dir(), 'pdf_').'.jpg';
+
+        file_put_contents($tmpPdf, $disk->get($media->getPath()));
+
+        (new Pdf($tmpPdf))->saveImage($tmpJpg);
+
+        $thumbPath = app(PathGenerator::class)->getDirectory($media).'/preview.jpg';
+        $disk->put($thumbPath, file_get_contents($tmpJpg));
+
+        $media->setCustomProperty('preview_path', $thumbPath);
+        $media->save();
+
+        @unlink($tmpPdf);
+        @unlink($tmpJpg);
+    }
+}
+```
+
+Render:
+
+```php
+$previewUrl = $media->filesystem()->url($media->getCustomProperty('preview_path'));
+```
+
+**Trade-offs:** Ghostscript + Imagick must be installed. For multi-page PDFs you may want to expose page selection or generate a stitched contact-sheet — start by handling page 1.
+
+---
+
+## Video thumbnail
+
+**Use case:** Show a still image for uploaded videos.
+
+**Approach:** Use [`pbmedia/laravel-ffmpeg`](https://github.com/protonemedia/laravel-ffmpeg) to grab a frame, written under the Media directory in the same pattern as the PDF recipe.
+
+```bash
+composer require pbmedia/laravel-ffmpeg
+# ffmpeg must be installed.
+```
+
+```php
+use Emaia\MediaMan\Events\MediaUploaded;
+use Emaia\MediaMan\Generators\PathGenerator;
+use ProtoneMedia\LaravelFFMpeg\Support\FFMpeg;
+
+class GenerateVideoThumbnail implements ShouldQueue
+{
+    public function handle(MediaUploaded $event): void
+    {
+        $media = $event->media;
+
+        if (! str_starts_with($media->mime_type, 'video/')) {
+            return;
+        }
+
+        $disk = $media->filesystem();
+        $thumbPath = app(PathGenerator::class)->getDirectory($media).'/poster.jpg';
+
+        // Read on the source disk, write the frame on the same disk.
+        FFMpeg::fromDisk($media->disk)
+            ->open($media->getPath())
+            ->getFrameFromSeconds(1)
+            ->export()
+            ->toDisk($media->disk)
+            ->save($thumbPath);
+
+        $media->setCustomProperty('poster_path', $thumbPath);
+        $media->save();
+    }
+}
+```
+
+**Trade-offs:** ffmpeg must be available on every worker. For long videos, dispatch a separate job with a longer queue timeout; the frame-extraction time grows with seek position.
+
+---
+
+## SVG to PNG fallback
+
+**Use case:** Convert SVG uploads to PNG so the rest of the conversion pipeline can resize them.
+
+**Approach:** In a `MediaUploaded` listener, rasterize the SVG with Imagick, store the PNG, and update `file_name` / `mime_type` on the original Media.
+
+```php
+use Emaia\MediaMan\Events\MediaUploaded;
+use Imagick;
+
+class RasterizeSvg implements ShouldQueue
+{
+    public function handle(MediaUploaded $event): void
+    {
+        $media = $event->media;
+
+        if ($media->mime_type !== 'image/svg+xml') {
+            return;
+        }
+
+        $disk = $media->filesystem();
+        $svg = $disk->get($media->getPath());
+
+        $imagick = new Imagick();
+        $imagick->setResolution(150, 150);
+        $imagick->readImageBlob($svg);
+        $imagick->setImageFormat('png');
+
+        // Save as a sibling, then update the Media to point at it.
+        $newName = pathinfo($media->file_name, PATHINFO_FILENAME).'.png';
+        $disk->put($media->getDirectory().'/'.$newName, $imagick->getImageBlob());
+
+        $imagick->clear();
+
+        $media->file_name = $newName;          // triggers automatic rename on disk
+        $media->mime_type = 'image/png';
+        $media->save();
+    }
+}
+```
+
+**Trade-offs:** Imagick must be installed. Be careful with untrusted SVGs — they can execute arbitrary network requests via `<image href="...">` during rasterization. Sanitize or sandbox in production.
+
+---
+
+## ZIP download of multiple media
+
+**Use case:** Let a user download a selection of media as a single archive.
+
+**Approach:** Stream the ZIP directly from a controller using [`maennchen/zipstream-php`](https://github.com/maennchen/ZipStream-PHP) — no temp file, scales to large archives.
+
+```bash
+composer require maennchen/zipstream-php
+```
+
+```php
+use Emaia\MediaMan\Models\Media;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use ZipStream\ZipStream;
+
+Route::get('/media/zip', function () {
+    $ids = request('ids', []);                   // ?ids[]=1&ids[]=2&...
+    $media = Media::whereIn('id', $ids)->get();
+
+    return new StreamedResponse(function () use ($media) {
+        $zip = new ZipStream(outputName: 'media.zip');
+
+        foreach ($media as $item) {
+            $zip->addFileFromStream($item->file_name, $item->getStream());
+        }
+
+        $zip->finish();
+    }, headers: ['Content-Type' => 'application/zip']);
+});
+```
+
+**Trade-offs:** Long-running downloads tie up a PHP worker. For 10+ GB archives, consider a queued S3 multipart upload + pre-signed URL instead.
+
+---
+
+## Multi-file form upload
+
+**Use case:** Handle `<input type="file" name="photos[]" multiple>` cleanly.
+
+**Approach:** Iterate `$request->file()` and call `source()` for each upload. Wrap in a transaction if you want all-or-nothing behavior.
+
+```php
+use Emaia\MediaMan\MediaUploader;
+use Illuminate\Support\Facades\DB;
+
+Route::post('/photos', function () {
+    $files = collect(request()->file('photos', []));
+
+    $media = DB::transaction(fn () => $files
+        ->map(fn ($file) => MediaUploader::source($file)
+            ->useCollection('Gallery')
+            ->upload())
+        ->all());
+
+    return ['attached' => count($media)];
+});
+```
+
+For attach to a model with a starting order:
+
+```php
+$post = Post::find(1);
+
+$startOrder = $post->getMedia('gallery')->count();
+
+foreach ($files as $i => $file) {
+    $media = MediaUploader::source($file)->upload();
+    $post->attachMedia($media, 'gallery', [], $startOrder + $i);
+}
+```
+
+**Trade-offs:** No special API for multi-file — but the iteration is one line, and you keep full control over per-file fluent options (different collections, custom properties, etc.).
+
+---
+
+## String or stream upload
+
+**Use case:** Persist programmatically generated data (a CSV string, a base64 payload from a job result, a stream from another API) as a Media without an `UploadedFile` instance.
+
+**Approach:** Write to a temp file, then funnel through `fromDisk()`.
+
+```php
+use Emaia\MediaMan\MediaUploader;
+use Illuminate\Support\Facades\Storage;
+
+// From a string
+function uploadFromString(string $content, string $filename): \Emaia\MediaMan\Models\Media
+{
+    Storage::disk('local')->put('tmp/'.$filename, $content);
+
+    $media = MediaUploader::fromDisk('tmp/'.$filename, 'local')
+        ->useFileName($filename)
+        ->upload();
+
+    Storage::disk('local')->delete('tmp/'.$filename);
+
+    return $media;
+}
+
+// From a stream
+function uploadFromStream($stream, string $filename): \Emaia\MediaMan\Models\Media
+{
+    Storage::disk('local')->writeStream('tmp/'.$filename, $stream);
+
+    $media = MediaUploader::fromDisk('tmp/'.$filename, 'local')
+        ->useFileName($filename)
+        ->upload();
+
+    Storage::disk('local')->delete('tmp/'.$filename);
+
+    return $media;
+}
+```
+
+**Trade-offs:** Two extra disk operations vs. a hypothetical native API. For small payloads the overhead is negligible; for huge streams, look at chunked uploads via `Storage::disk()->writeStream()` directly into a custom `MediaUploader` subclass.

--- a/docs/responsive-images.md
+++ b/docs/responsive-images.md
@@ -7,6 +7,7 @@
 - [Inspecting variants](#inspecting-variants)
 - [Getting a URL](#getting-a-url)
 - [srcset and `<picture>` HTML](#srcset-and-picture-html)
+- [Placeholder integration](#placeholder-integration)
 - [Clearing variants](#clearing-variants)
 - [Width calculators](#width-calculators)
 
@@ -134,6 +135,36 @@ Simple `<img>` (no `<picture>`):
 ```php
 echo $media->getSimpleImgHtml(['class' => 'hero-image', 'loading' => 'lazy']);
 // <img src="…/image.jpg" alt="My image" class="hero-image" loading="lazy">
+```
+
+## Placeholder integration
+
+When the LQIP placeholder (see [Media → Placeholder](media.md#placeholder-for-pending-conversions)) was generated at upload time (the feature is opt-in), `getPictureHtml()` and `getSimpleImgHtml()` inject it automatically as a CSS background-image on the inner `<img>`:
+
+```html
+<picture>
+    <source ...>
+    <img
+        src="…/image.jpg"
+        srcset="…"
+        style="background-image:url('data:image/jpeg;base64,…');background-size:cover;background-position:center;"
+        alt="…"
+    >
+</picture>
+```
+
+The background covers the slot during three real-world cases:
+
+- Right after upload, while the responsive job is still in the queue.
+- During the network download from the CDN.
+- For lazy-loaded media offscreen (`loading="lazy"`).
+
+The injection is silent when no placeholder exists (non-image upload, placeholder disabled in config, or generation failure). Disable per call with `['placeholder' => false]`:
+
+```php
+echo $media->getPictureHtml();                          // includes blur (default)
+echo $media->getPictureHtml(['placeholder' => false]);  // skip
+echo $media->getSimpleImgHtml(['style' => 'border-radius:8px']); // merges with your style
 ```
 
 ## Clearing variants

--- a/src/Console/Commands/MediamanCleanCommand.php
+++ b/src/Console/Commands/MediamanCleanCommand.php
@@ -19,7 +19,9 @@ or responsive files within a valid media directory are not flagged.';
 
     public function handle(): int
     {
-        $diskName = $this->option('disk') ?? config('mediaman.disk');
+        $diskName = $this->option('disk')
+            ?? config('mediaman.disk')
+            ?? config('filesystems.default');
         $dryRun = ! $this->option('force');
 
         try {

--- a/src/MediaManServiceProvider.php
+++ b/src/MediaManServiceProvider.php
@@ -88,7 +88,7 @@ class MediaManServiceProvider extends ServiceProvider
     protected function registerImageManager(): void
     {
         $this->app->singleton(ImageManager::class, function () {
-            $driver = config('mediaman.driver');
+            $driver = config('mediaman.driver') ?? $this->autoDetectImageDriver();
 
             return match ($driver) {
                 'imagick' => ImageManager::usingDriver(ImagickDriver::class),
@@ -98,6 +98,15 @@ class MediaManServiceProvider extends ServiceProvider
                 ),
             };
         });
+    }
+
+    /**
+     * Pick an image driver based on which PHP extensions are loaded.
+     * Prefers imagick (higher quality), falls back to gd.
+     */
+    protected function autoDetectImageDriver(): string
+    {
+        return extension_loaded('imagick') ? 'imagick' : 'gd';
     }
 
     /**

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -17,6 +17,8 @@ use Emaia\MediaMan\Traits\ResolvesModels;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Format;
+use Intervention\Image\ImageManager;
 
 class MediaUploader
 {
@@ -434,10 +436,22 @@ class MediaUploader
 
         $media->name = $this->name;
         $media->file_name = $this->fileName;
-        $media->disk = $this->disk ?: config('mediaman.disk');
+        $media->disk = $this->disk
+            ?: config('mediaman.disk')
+            ?: config('filesystems.default');
         $media->mime_type = $this->file->getMimeType();
         $media->size = $this->file->getSize();
-        $media->custom_properties = $this->custom_properties;
+        $properties = $this->custom_properties;
+
+        if ($this->shouldGeneratePlaceholder()) {
+            $placeholder = $this->generatePlaceholder($this->file->getPathname());
+
+            if ($placeholder !== null) {
+                $properties['placeholder'] = $placeholder;
+            }
+        }
+
+        $media->custom_properties = $properties;
 
         $media->save();
 
@@ -490,6 +504,41 @@ class MediaUploader
         $this->responsiveOptions = $options;
 
         return $this;
+    }
+
+    /**
+     * Determine whether to generate a placeholder for this upload.
+     */
+    protected function shouldGeneratePlaceholder(): bool
+    {
+        if (! config('mediaman.placeholder.enabled', true)) {
+            return false;
+        }
+
+        return str_starts_with($this->file->getMimeType() ?? '', 'image/');
+    }
+
+    /**
+     * Generate a tiny blurred placeholder data URI for an image file.
+     * Returns null on failure so the upload never breaks because of it.
+     */
+    protected function generatePlaceholder(string $path): ?string
+    {
+        try {
+            $width = (int) config('mediaman.placeholder.width', 32);
+            $blur = (int) config('mediaman.placeholder.blur', 20);
+            $quality = (int) config('mediaman.placeholder.quality', 40);
+
+            $encoded = app(ImageManager::class)
+                ->decode(file_get_contents($path))
+                ->scaleDown($width)
+                ->blur($blur)
+                ->encodeUsingFormat(Format::JPEG, quality: $quality);
+
+            return 'data:image/jpeg;base64,'.base64_encode((string) $encoded);
+        } catch (\Throwable) {
+            return null;
+        }
     }
 
     /**

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -459,6 +459,37 @@ class Media extends Model implements Attachable
     }
 
     /**
+     * Return the LQIP placeholder data URI generated at upload time, or null
+     * if none was generated (non-image, disabled in config, or failure).
+     */
+    public function getPlaceholder(): ?string
+    {
+        $value = $this->getCustomProperty('placeholder');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Return the conversion URL when the variant exists on disk; otherwise
+     * return the LQIP placeholder data URI; if neither is available, fall
+     * back to the original URL.
+     *
+     * Useful right after upload when queued conversions have not run yet.
+     */
+    public function getUrlOrPlaceholder(string $conversion = ''): string
+    {
+        if ($conversion !== '' && ! $this->hasConversion($conversion)) {
+            $placeholder = $this->getPlaceholder();
+
+            if ($placeholder !== null) {
+                return $placeholder;
+            }
+        }
+
+        return $this->getUrl($conversion);
+    }
+
+    /**
      * Get URL with fallback - returns conversion URL if exists, otherwise original.
      */
     public function getUrlWithFallback(string $conversion = ''): string

--- a/src/Traits/ResponsiveImages.php
+++ b/src/Traits/ResponsiveImages.php
@@ -35,10 +35,17 @@ trait ResponsiveImages
             return '';
         }
 
+        [$injectPlaceholder, $attributes] = $this->extractPlaceholderOption($attributes);
+
         $availableFormats = $this->getAvailableResponsiveFormats();
 
         // If no responsive images, return simple img tag
         if (empty($availableFormats) || $availableFormats === ['original']) {
+            // Re-inject opt-out so getSimpleImgHtml honors the same decision.
+            if (! $injectPlaceholder) {
+                $attributes['placeholder'] = false;
+            }
+
             return $this->getSimpleImgHtml($attributes, $sizes);
         }
 
@@ -88,6 +95,7 @@ trait ResponsiveImages
         }
 
         $imgAttributes = array_merge($defaultAttributes, $attributes);
+        $imgAttributes = $this->applyPlaceholderStyle($imgAttributes, $injectPlaceholder);
         $imgAttributesString = $this->attributesToString($imgAttributes);
 
         // Generate picture element
@@ -98,6 +106,48 @@ trait ResponsiveImages
         $sourcesString = implode("\n    ", $sources);
 
         return "<picture>\n    $sourcesString\n    <img $imgAttributesString>\n</picture>";
+    }
+
+    /**
+     * Pop the `placeholder` key out of the attributes array. Returns
+     * [bool $shouldInject, array $remainingAttributes] so callers can
+     * decide whether to add the blur background later without leaking
+     * the option into the rendered HTML.
+     */
+    protected function extractPlaceholderOption(array $attributes): array
+    {
+        $shouldInject = $attributes['placeholder'] ?? true;
+        unset($attributes['placeholder']);
+
+        return [(bool) $shouldInject, $attributes];
+    }
+
+    /**
+     * Append the LQIP placeholder as a CSS background-image on the <img>
+     * attributes when one was generated and the call opted in.
+     */
+    protected function applyPlaceholderStyle(array $attributes, bool $shouldInject): array
+    {
+        if (! $shouldInject) {
+            return $attributes;
+        }
+
+        $placeholder = $this->getPlaceholder();
+
+        if ($placeholder === null) {
+            return $attributes;
+        }
+
+        $background = "background-image:url('{$placeholder}');background-size:cover;background-position:center;";
+        $existing = trim($attributes['style'] ?? '');
+
+        if ($existing !== '') {
+            $existing = rtrim($existing, ';').';';
+        }
+
+        $attributes['style'] = $existing.$background;
+
+        return $attributes;
     }
 
     /**
@@ -146,7 +196,10 @@ trait ResponsiveImages
             return '';
         }
 
+        [$injectPlaceholder, $attributes] = $this->extractPlaceholderOption($attributes);
+
         $imgAttributes = array_merge($this->setDefaultImgAttributes($sizes), $attributes);
+        $imgAttributes = $this->applyPlaceholderStyle($imgAttributes, $injectPlaceholder);
         $imgAttributesString = $this->attributesToString($imgAttributes);
 
         return "<img $imgAttributesString>";

--- a/tests/Feature/ConfigDefaultsTest.php
+++ b/tests/Feature/ConfigDefaultsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Emaia\MediaMan\MediaUploader;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
+use Intervention\Image\ImageManager;
+
+// --- Image driver auto-detection ---
+
+it('uses the configured image driver when set explicitly', function () {
+    Config::set('mediaman.driver', 'gd');
+
+    app()->forgetInstance(ImageManager::class);
+
+    $manager = app(ImageManager::class);
+
+    expect($manager->driver)->toBeInstanceOf(GdDriver::class);
+});
+
+it('auto-detects the image driver when config is null', function () {
+    Config::set('mediaman.driver', null);
+
+    app()->forgetInstance(ImageManager::class);
+
+    $manager = app(ImageManager::class);
+
+    $expected = extension_loaded('imagick') ? ImagickDriver::class : GdDriver::class;
+
+    expect($manager->driver)->toBeInstanceOf($expected);
+});
+
+// --- Disk fallback ---
+
+it('falls back to filesystems.default when mediaman.disk is null', function () {
+    Storage::fake('fallback-disk');
+
+    Config::set('mediaman.disk', null);
+    Config::set('filesystems.default', 'fallback-disk');
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    expect($media->disk)->toEqual('fallback-disk');
+});
+
+it('honors mediaman.disk when explicitly set even if filesystems.default differs', function () {
+    Storage::fake('explicit-disk');
+
+    Config::set('mediaman.disk', 'explicit-disk');
+    Config::set('filesystems.default', 'other-disk');
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    expect($media->disk)->toEqual('explicit-disk');
+});

--- a/tests/Feature/PlaceholderTest.php
+++ b/tests/Feature/PlaceholderTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use Emaia\MediaMan\MediaUploader;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Config;
+
+beforeEach(function () {
+    // Placeholder is opt-in; enable it explicitly for these tests.
+    Config::set('mediaman.placeholder.enabled', true);
+});
+
+it('generates a placeholder data URI for image uploads', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $placeholder = $media->getPlaceholder();
+
+    expect($placeholder)->not->toBeNull()
+        ->and($placeholder)->toStartWith('data:image/jpeg;base64,');
+});
+
+it('does not generate a placeholder for non-image uploads', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->create('document.pdf', 100, 'application/pdf'))->upload();
+
+    expect($media->getPlaceholder())->toBeNull();
+});
+
+it('skips placeholder generation when disabled in config', function () {
+    Config::set('mediaman.placeholder.enabled', false);
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    expect($media->getPlaceholder())->toBeNull();
+});
+
+it('stores the placeholder under custom_properties', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    expect($media->custom_properties)->toHaveKey('placeholder')
+        ->and($media->custom_properties['placeholder'])->toStartWith('data:image/jpeg;base64,');
+});
+
+it('preserves user-provided custom properties alongside placeholder', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))
+        ->withCustomProperties(['author' => 'Alice'])
+        ->upload();
+
+    expect($media->custom_properties)->toHaveKey('author')
+        ->and($media->custom_properties['author'])->toEqual('Alice')
+        ->and($media->custom_properties)->toHaveKey('placeholder');
+});
+
+// --- getUrlOrPlaceholder ---
+
+it('getUrlOrPlaceholder returns the conversion URL when the file exists', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    // Without a conversion arg, returns the original URL
+    $url = $media->getUrlOrPlaceholder();
+
+    expect($url)->not->toStartWith('data:');
+});
+
+it('getUrlOrPlaceholder returns the placeholder when the conversion file is missing', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    // 'thumb' conversion never ran, file doesn't exist on disk
+    $url = $media->getUrlOrPlaceholder('thumb');
+
+    expect($url)->toStartWith('data:image/jpeg;base64,');
+});
+
+it('getUrlOrPlaceholder falls back to the URL when placeholder is also missing', function () {
+    Config::set('mediaman.placeholder.enabled', false);
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $url = $media->getUrlOrPlaceholder('thumb');
+
+    expect($url)->not->toStartWith('data:');
+});
+
+it('placeholder size stays within a reasonable budget (< 4 KB)', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg', 2000, 2000))->upload();
+
+    $placeholder = $media->getPlaceholder();
+
+    expect(strlen($placeholder))->toBeLessThan(4096);
+});
+
+// --- getPictureHtml / getSimpleImgHtml integration ---
+
+it('getSimpleImgHtml injects the placeholder as background-image when available', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $html = $media->getSimpleImgHtml();
+
+    expect($html)->toContain('background-image:url(')
+        ->and($html)->toContain('data:image/jpeg;base64,');
+});
+
+it('getSimpleImgHtml omits the background when placeholder is disabled globally', function () {
+    Config::set('mediaman.placeholder.enabled', false);
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $html = $media->getSimpleImgHtml();
+
+    expect($html)->not->toContain('background-image:url(');
+});
+
+it('getSimpleImgHtml omits the background when opted out per-call', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $html = $media->getSimpleImgHtml(['placeholder' => false]);
+
+    expect($html)->not->toContain('background-image:url(')
+        ->and($html)->not->toContain('placeholder');
+});
+
+it('getSimpleImgHtml merges placeholder into a user-provided style', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $html = $media->getSimpleImgHtml(['style' => 'border-radius:8px']);
+
+    expect($html)->toContain('border-radius:8px')
+        ->and($html)->toContain('background-image:url(');
+});
+
+it('getPictureHtml injects the placeholder on the inner img tag', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $html = $media->getPictureHtml();
+
+    expect($html)->toContain('background-image:url(')
+        ->and($html)->toContain('data:image/jpeg;base64,');
+});
+
+it('getPictureHtml honors the placeholder=false opt-out', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $html = $media->getPictureHtml(['placeholder' => false]);
+
+    expect($html)->not->toContain('background-image:url(');
+});


### PR DESCRIPTION
## Summary

### Native LQIP placeholder (opt-in)

Enable via `MEDIAMAN_PLACEHOLDER_ENABLED=true` to auto-generate a tiny blurred JPEG (~2 KB) on image upload, stored as a base64 data URI in `custom_properties.placeholder`.

- `Media::getPlaceholder(): ?string`
- `Media::getUrlOrPlaceholder(string \$conversion = ''): string` — returns the conversion URL when the file exists, falls back to the placeholder, then to the original URL. Solves the "view broken right after upload because queued conversions haven't run yet" UX gap.
- `getPictureHtml()` and `getSimpleImgHtml()` auto-inject the placeholder as a CSS background-image on the inner `<img>`. Per-call opt-out via `['placeholder' => false]`. Silent when no placeholder exists.

Default off, matching the package convention of opt-in feature toggles (mirrors `responsive_images.auto_generate`).

### Image driver auto-detection

`mediaman.driver` default is now `null` and auto-detected at boot — `imagick` when ext-imagick is loaded, `gd` otherwise. Previously hardcoded to `'imagick'`, which threw `InvalidArgumentException` at runtime on servers without ext-imagick.

### Disk null fallback

`mediaman.disk` default is now `null` and falls back to `config('filesystems.default')`. Previously hardcoded to `'public'`.

### Recipes

`docs/recipes.md` with 7 pluggable patterns for needs deliberately not shipped in core: image optimization, PDF/video thumbnails, SVG rasterization, ZIP downloads, multi-file uploads, string/stream uploads. Each recipe consumes the package's events + custom_properties + PathGenerator to slot cleanly into the existing pipeline.

### CI / release tooling

- CI now runs PHPStan and Pint jobs in parallel with the pest matrix — would have caught a few regressions during this release cycle.
- New \`.github/workflows/release.yml\` creates a GitHub Release automatically when a \`v*\` tag is pushed, extracting the matching section from \`CHANGELOG.md\`. The manual \`gh release create --notes-file …\` step is no longer needed.
- New \`.github/PULL_REQUEST_TEMPLATE.md\` prompts contributors to update CHANGELOG and docs.

### Housekeeping

- Move v2.10.0 entries from \`[Unreleased]\` to a proper \`[2.10.0]\` header in CHANGELOG.md (oversight in the previous release).
- Update README docs table line for Recipes (LQIP recipe was promoted to native).

## Test plan

- [x] \`composer test\` — 541/541 (1 skip env-dependent)
- [x] \`composer analyse\` — clean
- [x] \`vendor/bin/pint --test\` — clean
- [ ] Manual: render \`getPictureHtml()\` after upload with \`MEDIAMAN_PLACEHOLDER_ENABLED=true\`, confirm \`style="background-image:..."\` on the inner img
- [ ] Manual: with \`MEDIAMAN_PLACEHOLDER_ENABLED=false\`, confirm no background injected
- [ ] Manual: in a container without ext-imagick, confirm uploads work without setting \`MEDIAMAN_DRIVER=gd\`
- [ ] Manual: unset \`mediaman.disk\`, change \`filesystems.default\`, upload, confirm fallback honored
- [ ] CI: PHPStan + Pint jobs run green
- [ ] Tag a test release on a fork, confirm release.yml extracts and publishes notes