### PR TITLE
Add mediaman:rotate-paths command for APP_KEY rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `emaia/laravel-mediaman` will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `mediaman:rotate-paths` artisan command — renames the on-disk media directories after an `APP_KEY` rotation. Iterates `Media` records, computes the path under the previous key vs the current key, and physically moves files when they differ. Dry-run by default; `--force` applies the moves; `--disk` and `--media` scope the operation; idempotent across re-runs. See [Security → APP_KEY rotation](docs/security.md#app_key-rotation) and [Commands → Rotate media paths after APP_KEY rotation](docs/commands.md#rotate-media-paths-after-app_key-rotation).
+
 ## [2.11.0] — 2026-06-17
 
 ### Changed

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -43,27 +43,32 @@ The command also detects reverse orphans (Media records whose file is missing fr
 
 ## Rotate media paths after APP_KEY rotation
 
-The default storage layout hashes `APP_KEY` into each media directory (`{id}-{md5(id . app_key)}`). Rotating the key would silently break URLs to existing media unless you rename the on-disk directories first.
+The default storage layout hashes `APP_KEY` into each media directory (`{id}-{md5(id . app_key)}`). Rotating the key would silently break URLs to existing media unless you rename the on-disk directories.
 
-```bash
-# Dry-run (default) — reports what would be moved
-php artisan mediaman:rotate-paths --old-key="base64:..."
-
-# Actually move
-php artisan mediaman:rotate-paths --old-key="base64:..." --force
-
-# Scope to a single disk
-php artisan mediaman:rotate-paths --old-key="base64:..." --force --disk=s3-media
-
-# Scope to a single Media id (handy for recovery / partial replays)
-php artisan mediaman:rotate-paths --old-key="base64:..." --force --media=42
-```
+The command computes the target directory using the **current** `config('app.key')` and the source directory using the `--old-key` you pass. **You must rotate the key first**, then run the command with the previous key as `--old-key`. If `--old-key` equals the current `config('app.key')`, the command reports "Nothing to rotate" and exits — that's the noop you get when the order is reversed.
 
 Workflow:
 
 ```bash
-php artisan mediaman:rotate-paths --old-key="base64:..." --force   # rename on disk
-php artisan key:generate                                           # rotate the key
+# 1. Note the current APP_KEY before rotating
+OLD_KEY="base64:..."
+
+# 2. Rotate the key
+php artisan key:generate
+
+# 3. Rename on-disk directories using the saved old key
+php artisan mediaman:rotate-paths --old-key="$OLD_KEY"          # dry-run
+php artisan mediaman:rotate-paths --old-key="$OLD_KEY" --force  # actually move
+```
+
+Scoping options:
+
+```bash
+# Scope to a single disk
+php artisan mediaman:rotate-paths --old-key="$OLD_KEY" --force --disk=s3-media
+
+# Scope to a single Media id (handy for recovery / partial replays)
+php artisan mediaman:rotate-paths --old-key="$OLD_KEY" --force --media=42
 ```
 
 The command is idempotent: re-runs against already-migrated media report them as "already migrated" and skip. See [Security → APP_KEY rotation](security.md#app_key-rotation) for context.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4,6 +4,7 @@
 
 - [Publish assets](#publish-assets)
 - [Clean orphaned files](#clean-orphaned-files)
+- [Rotate media paths after APP_KEY rotation](#rotate-media-paths-after-app_key-rotation)
 - [Generate responsive images](#generate-responsive-images)
 - [Clear responsive images](#clear-responsive-images)
 - [Responsive images stats](#responsive-images-stats)
@@ -39,6 +40,33 @@ php artisan mediaman:clean --disk=media
 ```
 
 The command also detects reverse orphans (Media records whose file is missing from disk) and reports them for manual review — **DB records are never auto-deleted**. See [Security → mediaman:clean](security.md#detect-orphaned-files).
+
+## Rotate media paths after APP_KEY rotation
+
+The default storage layout hashes `APP_KEY` into each media directory (`{id}-{md5(id . app_key)}`). Rotating the key would silently break URLs to existing media unless you rename the on-disk directories first.
+
+```bash
+# Dry-run (default) — reports what would be moved
+php artisan mediaman:rotate-paths --old-key="base64:..."
+
+# Actually move
+php artisan mediaman:rotate-paths --old-key="base64:..." --force
+
+# Scope to a single disk
+php artisan mediaman:rotate-paths --old-key="base64:..." --force --disk=s3-media
+
+# Scope to a single Media id (handy for recovery / partial replays)
+php artisan mediaman:rotate-paths --old-key="base64:..." --force --media=42
+```
+
+Workflow:
+
+```bash
+php artisan mediaman:rotate-paths --old-key="base64:..." --force   # rename on disk
+php artisan key:generate                                           # rotate the key
+```
+
+The command is idempotent: re-runs against already-migrated media report them as "already migrated" and skip. See [Security → APP_KEY rotation](security.md#app_key-rotation) for context.
 
 ## Generate responsive images
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,6 +5,7 @@
 - [Disallowed file extensions](#disallowed-file-extensions)
 - [SSRF protection for remote URLs](#ssrf-protection-for-remote-urls)
 - [Detect orphaned files](#detect-orphaned-files)
+- [`APP_KEY` rotation](#app_key-rotation)
 - [Custom paths and URLs](#custom-paths-and-urls)
 
 ## Disallowed file extensions
@@ -79,6 +80,32 @@ The command reports two kinds of orphans:
 - **Media records** pointing to missing files → reported only, **never auto-deleted** (cascade safety: a record may belong to multiple collections, channels, or models)
 
 Detection works at the top-level media directory. Stale conversion or responsive variants inside a valid media directory are not flagged.
+
+## `APP_KEY` rotation
+
+`DefaultPathGenerator` includes `APP_KEY` in the obfuscation hash: the directory is `{id}-{md5(id . app_key)}`. Rotating the key would silently change every computed path, breaking URLs to all existing media.
+
+**Plan the rotation as a two-step operation**, just like any other `APP_KEY` rotation (encrypted columns, signed URLs, sessions, etc.):
+
+```bash
+# 1. Rename the on-disk directories using the previous key
+php artisan mediaman:rotate-paths --old-key="base64:..."         # dry-run by default
+php artisan mediaman:rotate-paths --old-key="base64:..." --force # actually move
+
+# 2. Roll the key
+php artisan key:generate
+```
+
+The command iterates `Media` records, computes the directory under the old and new keys, and physically renames on disk when they differ. Options:
+
+- `--old-key` (required) — the value `config('app.key')` returned *before* rotation
+- `--force` — actually move files (without it, only reports planned moves)
+- `--disk=...` — scope to a specific disk
+- `--media=ID` — scope to a single Media id (handy for recovery)
+
+It's safe to re-run: media whose files are already at the new location are reported as "already migrated" and skipped. Media with both old and new directories present (partial previous run) are flagged for manual review without touching anything.
+
+If you'd rather decouple paths from the key entirely, swap `PathGenerator` for a custom implementation that uses random tokens or another scheme — see [Configuration → Pluggable generators](configuration.md#pluggable-generators).
 
 ## Custom paths and URLs
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -85,20 +85,25 @@ Detection works at the top-level media directory. Stale conversion or responsive
 
 `DefaultPathGenerator` includes `APP_KEY` in the obfuscation hash: the directory is `{id}-{md5(id . app_key)}`. Rotating the key would silently change every computed path, breaking URLs to all existing media.
 
-**Plan the rotation as a two-step operation**, just like any other `APP_KEY` rotation (encrypted columns, signed URLs, sessions, etc.):
+**Plan the rotation as a three-step operation**, just like any other `APP_KEY` rotation (encrypted columns, signed URLs, sessions, etc.):
 
 ```bash
-# 1. Rename the on-disk directories using the previous key
-php artisan mediaman:rotate-paths --old-key="base64:..."         # dry-run by default
-php artisan mediaman:rotate-paths --old-key="base64:..." --force # actually move
+# 1. Note the current APP_KEY before rotating — you'll need it as --old-key below.
+#    (Read it from .env or with `php artisan tinker --execute='echo config("app.key");'`)
+OLD_KEY="base64:..."
 
-# 2. Roll the key
+# 2. Rotate the key. After this, config('app.key') returns the NEW value.
 php artisan key:generate
+
+# 3. Rename the on-disk directories. The command uses config('app.key') as the
+#    target and the value passed to --old-key as the source.
+php artisan mediaman:rotate-paths --old-key="$OLD_KEY"          # dry-run by default
+php artisan mediaman:rotate-paths --old-key="$OLD_KEY" --force  # actually move
 ```
 
 The command iterates `Media` records, computes the directory under the old and new keys, and physically renames on disk when they differ. Options:
 
-- `--old-key` (required) — the value `config('app.key')` returned *before* rotation
+- `--old-key` (required) — the value `config('app.key')` returned **before** the rotation. The command compares it against the current `config('app.key')` — if they match, nothing happens, so you must rotate first and then run the command.
 - `--force` — actually move files (without it, only reports planned moves)
 - `--disk=...` — scope to a specific disk
 - `--media=ID` — scope to a single Media id (handy for recovery)

--- a/src/Console/Commands/MediamanRotatePathsCommand.php
+++ b/src/Console/Commands/MediamanRotatePathsCommand.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Emaia\MediaMan\Console\Commands;
+
+use Emaia\MediaMan\Models\Media;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class MediamanRotatePathsCommand extends Command
+{
+    protected $signature = 'mediaman:rotate-paths
+                            {--old-key= : The previous APP_KEY (the value config(\'app.key\') returned before rotation)}
+                            {--disk= : Limit to a specific disk}
+                            {--media= : Limit to a single Media id}
+                            {--force : Actually move files (default is dry-run)}';
+
+    protected $description = 'Rename media directories on disk after rotating APP_KEY';
+
+    public function handle(): int
+    {
+        $oldKey = $this->option('old-key');
+
+        if (empty($oldKey)) {
+            $this->error('--old-key is required. Pass the previous value of APP_KEY (the full string, including the "base64:" prefix when present).');
+
+            return self::FAILURE;
+        }
+
+        $currentKey = config('app.key');
+
+        if ($oldKey === $currentKey) {
+            $this->warn('--old-key matches the current app.key. Nothing to rotate.');
+
+            return self::SUCCESS;
+        }
+
+        $dryRun = ! $this->option('force');
+
+        if ($dryRun) {
+            $this->info('Dry run — no files will be moved. Re-run with --force to apply.');
+        }
+
+        $query = Media::query();
+
+        if ($id = $this->option('media')) {
+            $query->whereKey($id);
+        }
+
+        if ($disk = $this->option('disk')) {
+            $query->where('disk', $disk);
+        }
+
+        $renamed = 0;
+        $skippedAlreadyMigrated = 0;
+        $skippedMissing = 0;
+        $skippedConflict = 0;
+
+        $query->cursor()->each(function (Media $media) use (
+            $oldKey, $currentKey, $dryRun,
+            &$renamed, &$skippedAlreadyMigrated, &$skippedMissing, &$skippedConflict
+        ) {
+            $oldDir = $media->getKey().'-'.md5($media->getKey().$oldKey);
+            $newDir = $media->getKey().'-'.md5($media->getKey().$currentKey);
+
+            if ($oldDir === $newDir) {
+                return;
+            }
+
+            try {
+                $filesystem = Storage::disk($media->disk);
+            } catch (\InvalidArgumentException $e) {
+                $this->warn("  Media {$media->getKey()}: disk [{$media->disk}] not configured, skipping.");
+
+                return;
+            }
+
+            $oldExists = $filesystem->exists($oldDir);
+            $newExists = $filesystem->exists($newDir);
+
+            if (! $oldExists) {
+                if ($newExists) {
+                    $this->line("  <fg=blue>Media {$media->getKey()}</>: already at {$newDir}, skipping.");
+                    $skippedAlreadyMigrated++;
+                } else {
+                    $this->warn("  Media {$media->getKey()}: neither {$oldDir} nor {$newDir} exists on disk [{$media->disk}].");
+                    $skippedMissing++;
+                }
+
+                return;
+            }
+
+            if ($newExists) {
+                $this->warn("  Media {$media->getKey()}: both {$oldDir} and {$newDir} exist. Manual review required.");
+                $skippedConflict++;
+
+                return;
+            }
+
+            // $oldExists && ! $newExists — the rename we want to do.
+            if ($dryRun) {
+                $this->line("  <fg=yellow>Media {$media->getKey()}</>: would move {$oldDir} → {$newDir}");
+                $renamed++;
+
+                return;
+            }
+
+            $files = $filesystem->allFiles($oldDir);
+
+            foreach ($files as $file) {
+                $relative = substr($file, strlen($oldDir) + 1);
+                $filesystem->move($file, $newDir.'/'.$relative);
+            }
+
+            // Clean up the now-empty source directory (some drivers keep
+            // empty directories around after moving the last file out).
+            $filesystem->deleteDirectory($oldDir);
+
+            $fileCount = count($files);
+            $this->line("  <fg=green>Media {$media->getKey()}</>: moved {$oldDir} → {$newDir} ({$fileCount} file(s))");
+            $renamed++;
+        });
+
+        $this->newLine();
+        $this->info(($dryRun ? 'Would rename' : 'Renamed').": {$renamed}");
+
+        if ($skippedAlreadyMigrated > 0) {
+            $this->line("Already migrated: {$skippedAlreadyMigrated}");
+        }
+
+        if ($skippedMissing > 0) {
+            $this->line("Missing on disk:  {$skippedMissing}");
+        }
+
+        if ($skippedConflict > 0) {
+            $this->warn("Conflicts (both old + new exist): {$skippedConflict}");
+        }
+
+        if ($dryRun && $renamed > 0) {
+            $this->newLine();
+            $this->comment('Re-run with --force to apply the moves.');
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/MediaManServiceProvider.php
+++ b/src/MediaManServiceProvider.php
@@ -8,6 +8,7 @@ use Emaia\MediaMan\Console\Commands\MediamanCleanCommand;
 use Emaia\MediaMan\Console\Commands\MediamanPublishCommand;
 use Emaia\MediaMan\Console\Commands\MediamanPublishConfigCommand;
 use Emaia\MediaMan\Console\Commands\MediamanPublishMigrationCommand;
+use Emaia\MediaMan\Console\Commands\MediamanRotatePathsCommand;
 use Emaia\MediaMan\Console\Commands\ResponsiveImagesStatsCommand;
 use Emaia\MediaMan\Downloaders\Downloader;
 use Emaia\MediaMan\Downloaders\HttpDownloader;
@@ -73,6 +74,7 @@ class MediaManServiceProvider extends ServiceProvider
                 ClearResponsiveImagesCommand::class,
                 ResponsiveImagesStatsCommand::class,
                 MediamanCleanCommand::class,
+                MediamanRotatePathsCommand::class,
             ]);
         }
 

--- a/tests/Feature/Commands/MediamanRotatePathsCommandTest.php
+++ b/tests/Feature/Commands/MediamanRotatePathsCommandTest.php
@@ -1,0 +1,190 @@
+<?php
+
+use Emaia\MediaMan\MediaUploader;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+
+function rotatePathsKeyPair(): array
+{
+    $oldKey = 'base64:'.base64_encode(str_repeat('x', 32));
+    $newKey = 'base64:'.base64_encode(str_repeat('y', 32));
+
+    return [$oldKey, $newKey];
+}
+
+function expectedDirFor(int $id, string $key): string
+{
+    return $id.'-'.md5($id.$key);
+}
+
+it('requires --old-key', function () {
+    $this->artisan('mediaman:rotate-paths')
+        ->expectsOutputToContain('--old-key is required')
+        ->assertExitCode(1);
+});
+
+it('noops when --old-key matches the current key', function () {
+    $this->artisan('mediaman:rotate-paths', ['--old-key' => config('app.key')])
+        ->expectsOutputToContain('matches the current app.key')
+        ->assertExitCode(0);
+});
+
+it('reports planned moves in dry-run mode without touching disk', function () {
+    [$oldKey, $newKey] = rotatePathsKeyPair();
+
+    Config::set('app.key', $oldKey);
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+    $oldDir = $media->getDirectory();
+
+    Config::set('app.key', $newKey);
+
+    $this->artisan('mediaman:rotate-paths', ['--old-key' => $oldKey])
+        ->expectsOutputToContain('Dry run')
+        ->expectsOutputToContain('would move')
+        ->assertExitCode(0);
+
+    // File still at the old location after dry-run
+    expect(Storage::disk($media->disk)->exists($oldDir))->toBeTrue();
+});
+
+it('actually moves files when --force is passed', function () {
+    [$oldKey, $newKey] = rotatePathsKeyPair();
+
+    Config::set('app.key', $oldKey);
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+    $oldDir = $media->getDirectory();
+
+    Config::set('app.key', $newKey);
+    $newDir = expectedDirFor($media->id, $newKey);
+
+    expect(Storage::disk($media->disk)->exists($oldDir))->toBeTrue();
+    expect(Storage::disk($media->disk)->exists($newDir))->toBeFalse();
+
+    $this->artisan('mediaman:rotate-paths', ['--old-key' => $oldKey, '--force' => true])
+        ->expectsOutputToContain('Renamed: 1')
+        ->assertExitCode(0);
+
+    expect(Storage::disk($media->disk)->exists($oldDir))->toBeFalse();
+    expect(Storage::disk($media->disk)->exists($newDir.'/'.$media->file_name))->toBeTrue();
+});
+
+it('skips media whose files are already at the new path', function () {
+    [$oldKey, $newKey] = rotatePathsKeyPair();
+
+    Config::set('app.key', $newKey); // Upload directly under the new key
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $this->artisan('mediaman:rotate-paths', ['--old-key' => $oldKey, '--force' => true])
+        ->expectsOutputToContain('already at')
+        ->expectsOutputToContain('Already migrated: 1')
+        ->assertExitCode(0);
+});
+
+it('flags media with both old and new directories present as conflict', function () {
+    [$oldKey, $newKey] = rotatePathsKeyPair();
+
+    Config::set('app.key', $oldKey);
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    Config::set('app.key', $newKey);
+    // Simulate a partial previous run leaving both directories on disk
+    $newDir = expectedDirFor($media->id, $newKey);
+    Storage::disk($media->disk)->put($newDir.'/stray.txt', 'leftover');
+
+    $this->artisan('mediaman:rotate-paths', ['--old-key' => $oldKey, '--force' => true])
+        ->expectsOutputToContain('Manual review required')
+        ->expectsOutputToContain('Conflicts')
+        ->assertExitCode(0);
+
+    // Nothing was moved
+    expect(Storage::disk($media->disk)->exists($media->getDirectory()))->toBeTrue();
+});
+
+it('--disk scopes the operation', function () {
+    [$oldKey, $newKey] = rotatePathsKeyPair();
+
+    Storage::fake('other-disk');
+
+    Config::set('app.key', $oldKey);
+    $mediaDefault = MediaUploader::source(UploadedFile::fake()->image('a.jpg'))->upload();
+    $mediaOther = MediaUploader::source(UploadedFile::fake()->image('b.jpg'))->useDisk('other-disk')->upload();
+
+    Config::set('app.key', $newKey);
+
+    $this->artisan('mediaman:rotate-paths', [
+        '--old-key' => $oldKey,
+        '--disk' => 'other-disk',
+        '--force' => true,
+    ])->assertExitCode(0);
+
+    // other-disk media moved to new dir, old dir gone
+    $oldDirOther = expectedDirFor($mediaOther->id, $oldKey);
+    $newDirOther = expectedDirFor($mediaOther->id, $newKey);
+    expect(Storage::disk('other-disk')->exists($oldDirOther))->toBeFalse();
+    expect(Storage::disk('other-disk')->exists($newDirOther.'/'.$mediaOther->file_name))->toBeTrue();
+
+    // default disk untouched (still at the old directory)
+    $oldDirDefault = expectedDirFor($mediaDefault->id, $oldKey);
+    expect(Storage::disk($mediaDefault->disk)->exists($oldDirDefault))->toBeTrue();
+});
+
+it('--media scopes to a single id', function () {
+    [$oldKey, $newKey] = rotatePathsKeyPair();
+
+    Config::set('app.key', $oldKey);
+    $m1 = MediaUploader::source(UploadedFile::fake()->image('a.jpg'))->upload();
+    $m2 = MediaUploader::source(UploadedFile::fake()->image('b.jpg'))->upload();
+
+    Config::set('app.key', $newKey);
+
+    $this->artisan('mediaman:rotate-paths', [
+        '--old-key' => $oldKey,
+        '--media' => $m1->id,
+        '--force' => true,
+    ])->assertExitCode(0);
+
+    expect(Storage::disk($m1->disk)->exists(expectedDirFor($m1->id, $newKey).'/'.$m1->file_name))->toBeTrue();
+    // m2 unchanged
+    expect(Storage::disk($m2->disk)->exists(expectedDirFor($m2->id, $oldKey).'/'.$m2->file_name))->toBeTrue();
+});
+
+it('warns when media directory is missing entirely', function () {
+    [$oldKey, $newKey] = rotatePathsKeyPair();
+
+    Config::set('app.key', $oldKey);
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    // Wipe the directory
+    Storage::disk($media->disk)->deleteDirectory($media->getDirectory());
+
+    Config::set('app.key', $newKey);
+
+    $this->artisan('mediaman:rotate-paths', ['--old-key' => $oldKey, '--force' => true])
+        ->expectsOutputToContain('neither')
+        ->expectsOutputToContain('Missing on disk:  1')
+        ->assertExitCode(0);
+});
+
+it('moves conversion + responsive subfiles along with the primary file', function () {
+    [$oldKey, $newKey] = rotatePathsKeyPair();
+
+    Config::set('app.key', $oldKey);
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+    $oldDir = $media->getDirectory();
+
+    // Drop a fake conversion and responsive sibling into the old directory
+    Storage::disk($media->disk)->put($oldDir.'/conversions/thumb/photo.jpg', 'fake-thumb');
+    Storage::disk($media->disk)->put($oldDir.'/responsive/photo_320w.webp', 'fake-webp');
+
+    Config::set('app.key', $newKey);
+    $newDir = expectedDirFor($media->id, $newKey);
+
+    $this->artisan('mediaman:rotate-paths', ['--old-key' => $oldKey, '--force' => true])
+        ->assertExitCode(0);
+
+    expect(Storage::disk($media->disk)->exists($newDir.'/'.$media->file_name))->toBeTrue();
+    expect(Storage::disk($media->disk)->exists($newDir.'/conversions/thumb/photo.jpg'))->toBeTrue();
+    expect(Storage::disk($media->disk)->exists($newDir.'/responsive/photo_320w.webp'))->toBeTrue();
+    expect(Storage::disk($media->disk)->exists($oldDir))->toBeFalse();
+});


### PR DESCRIPTION
## Summary

- New \`mediaman:rotate-paths\` artisan command that renames on-disk media directories after rotating \`APP_KEY\`.
- The default \`PathGenerator\` hashes \`APP_KEY\` into each directory (\`{id}-{md5(id . app_key)}\`); without a rename step, key rotation would silently break every existing media URL.
- Dry-run by default; \`--force\` applies the moves; \`--disk\` and \`--media\` scope the operation; idempotent across re-runs.

## Why this approach

Considered a persisted \`path\` column with an Eloquent \`created\` event populator. Decided against it after weighing trade-offs:

- That approach trades one rare problem (key rotation) for several quieter ones: extra UPDATE per upload, hidden event-driven mutation, bulk-insert blind spot, silent disaster path if users forget the backfill.
- Laravel itself treats \`APP_KEY\` rotation as a planned operation (encrypted columns, signed URLs, sessions all break). A command surfaces the same expectation honestly without changing the model or schema.
- This PR keeps performance identical, zero BC, zero new edge cases — only adds a tool for the specific moment it's needed.

## Test plan

- [x] \`composer test\` — 551/551 (1 skip env-dependent)
- [x] \`composer analyse\` — clean
- [x] \`vendor/bin/pint --test\` — clean
- [ ] Manual: upload media, copy current \`APP_KEY\`, rotate, run \`mediaman:rotate-paths --old-key=<old> --force\`, confirm URLs resolve
- [ ] Manual: re-run the command, confirm \"already migrated\" output
- [ ] Manual: run with \`--media=42\` to scope to a single id

## Documentation

- [x] \`CHANGELOG.md\` updated under \`[Unreleased]\`
- [x] \`docs/security.md\` — new \"APP_KEY rotation\" section with the runbook
- [x] \`docs/commands.md\` — new section documenting the command