### PR TITLE
Always emit <picture>, with one <source> per responsive format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `emaia/laravel-mediaman` will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- `getPictureHtml()` always emits a `<picture>` wrapper, even when no responsive variants exist (`<picture><img></picture>`). Previously the method silently fell through to `getSimpleImgHtml()` and returned a bare `<img>` in that case — and also when only a single responsive format was configured (the default `formats=['webp']`), which left the rendered output without a `<picture>` despite the variants being there. Markup shape is now consistent across all states.
+- `<source>` elements now cover **every** responsive format. Previously the last format was reserved for the inner `<img>` srcset, which mis-categorised single-format setups (e.g. WebP variants attached to a JPEG original) by mixing formats inside `<img srcset>`. The `<img>` always points at the original file now, with its native width as a single `srcset` candidate.
+- `getSrcset()` filters out responsive entries with empty URL or zero width before assembling the string — degenerate data no longer surfaces as malformed `<source>` tags.
+
+### Notes
+
+- `getSimpleImgHtml()` is unchanged and remains the explicit escape hatch when callers need a bare `<img>` (email templates, etc.).
+
 ## [2.12.0] — 2026-06-17
 
 ### Added

--- a/docs/responsive-images.md
+++ b/docs/responsive-images.md
@@ -108,7 +108,7 @@ $media->getSrcset();          // best format
 $media->getSrcset('webp');    // specific format
 ```
 
-`getPictureHtml()` produces a `<picture>` element with `<source>` tags per available format (modern formats first) and an `<img>` fallback. Without variants it falls back to a plain `<img>`.
+`getPictureHtml()` always produces a `<picture>` element: one `<source>` per responsive format (modern formats first) plus an `<img>` fallback pointing at the original file. When no responsive variants exist the wrapper stays — `<picture><img></picture>` — so callers can rely on a single markup shape regardless of pipeline state.
 
 ```php
 echo $media->getPictureHtml();
@@ -120,17 +120,19 @@ echo $media->getPictureHtml(['class' => 'hero-image'], '(max-width: 640px) 100vw
 echo $media->getPictureHtml([], 'auto');  // sizes computed from breakpoints
 ```
 
-Example output:
+Example output with two responsive formats and a JPEG original:
 
 ```html
 <picture>
     <source type="image/avif" srcset="…/image-320.avif 320w, …/image-640.avif 640w, …" sizes="…">
     <source type="image/webp" srcset="…/image-320.webp 320w, …/image-640.webp 640w, …" sizes="…">
-    <img src="…/image.jpg" alt="My image" srcset="…/image-320.jpg 320w, …" sizes="…">
+    <img src="…/image.jpg" alt="My image" srcset="…/image.jpg 1920w">
 </picture>
 ```
 
-Simple `<img>` (no `<picture>`):
+Browsers that understand AVIF pick from the first `<source>`; older ones fall through to WebP; the `<img>` covers anything that supports neither. The `<img srcset>` exposes the original's native width as a single candidate so the fallback path is still width-aware.
+
+Need a bare `<img>` without the wrapper (email templates, very constrained markup)? Use `getSimpleImgHtml()`:
 
 ```php
 echo $media->getSimpleImgHtml(['class' => 'hero-image', 'loading' => 'lazy']);

--- a/src/Traits/ResponsiveImages.php
+++ b/src/Traits/ResponsiveImages.php
@@ -27,7 +27,14 @@ trait ResponsiveImages
     }
 
     /**
-     * Get picture element HTML with multiple formats.
+     * Render a `<picture>` element wrapping the media. Every responsive
+     * format becomes a `<source>` (modern formats first); the inner `<img>`
+     * always points at the original file as the browser-agnostic fallback.
+     *
+     * The wrapper is emitted even when no responsive variants exist — the
+     * markup shape stays consistent (`<picture><img></picture>`) and callers
+     * can rely on it. `getSimpleImgHtml()` remains the explicit escape hatch
+     * for contexts that need a bare `<img>` (email templates, etc.).
      */
     public function getPictureHtml(array $attributes = [], $sizes = null): string
     {
@@ -37,26 +44,45 @@ trait ResponsiveImages
 
         [$injectPlaceholder, $attributes] = $this->extractPlaceholderOption($attributes);
 
-        $availableFormats = $this->getAvailableResponsiveFormats();
-
-        // If no responsive images, return simple img tag
-        if (empty($availableFormats) || $availableFormats === ['original']) {
-            // Re-inject opt-out so getSimpleImgHtml honors the same decision.
-            if (! $injectPlaceholder) {
-                $attributes['placeholder'] = false;
-            }
-
-            return $this->getSimpleImgHtml($attributes, $sizes);
-        }
-
         $defaultAttributes = $this->setDefaultImgAttributes($sizes);
 
-        $sources = [];
+        $sources = $this->buildResponsiveSourceElements($defaultAttributes['sizes'] ?? null);
 
-        // Define format priority (modern formats first)
+        // The <img> fallback always carries the original file. Its srcset
+        // declares the original at its native width so browsers that ignore
+        // every <source> still receive a width-aware candidate.
+        $originalWidth = $this->getImageWidth();
+        if ($originalWidth > 0) {
+            $defaultAttributes['srcset'] = $this->getUrl().' '.$originalWidth.'w';
+        }
+
+        $imgAttributes = array_merge($defaultAttributes, $attributes);
+        $imgAttributes = $this->applyPlaceholderStyle($imgAttributes, $injectPlaceholder);
+        $imgAttributesString = $this->attributesToString($imgAttributes);
+
+        if (empty($sources)) {
+            return "<picture>\n    <img $imgAttributesString>\n</picture>";
+        }
+
+        $sourcesString = implode("\n    ", $sources);
+
+        return "<picture>\n    $sourcesString\n    <img $imgAttributesString>\n</picture>";
+    }
+
+    /**
+     * Build one `<source>` per responsive format, ordered modern-first.
+     * Returns an empty array when no responsive variants exist.
+     */
+    protected function buildResponsiveSourceElements(?string $sizes): array
+    {
+        $availableFormats = $this->getAvailableResponsiveFormats();
+
+        if (empty($availableFormats) || $availableFormats === ['original']) {
+            return [];
+        }
+
         $formatPriority = array_map(fn (MediaFormat $f) => $f->value, MediaFormat::responsiveFormats());
 
-        // Sort available formats by priority
         $sortedFormats = [];
         foreach ($formatPriority as $priorityFormat) {
             if (in_array($priorityFormat, $availableFormats)) {
@@ -64,48 +90,30 @@ trait ResponsiveImages
             }
         }
 
-        // Add any remaining formats
         foreach ($availableFormats as $format) {
             if (! in_array($format, $sortedFormats)) {
                 $sortedFormats[] = $format;
             }
         }
 
-        // Generate source elements (exclude the last format for fallback)
-        $sourceFormats = array_slice($sortedFormats, 0, -1);
-        foreach ($sourceFormats as $format) {
+        $sources = [];
+        foreach ($sortedFormats as $format) {
             $srcset = $this->getSrcset($format);
-            if ($srcset) {
-                $mimeType = $this->formatToMimeType($format);
-                $sourceHtml = "<source type=\"{$mimeType}\" srcset=\"{$srcset}\"";
-                if (! empty($defaultAttributes['sizes'])) {
-                    $sourceHtml .= " sizes=\"{$defaultAttributes['sizes']}\"";
-                }
-                $sourceHtml .= '>';
-                $sources[] = $sourceHtml;
+            if (! $srcset) {
+                continue;
             }
+
+            $mimeType = $this->formatToMimeType($format);
+            $sourceHtml = "<source type=\"{$mimeType}\" srcset=\"{$srcset}\"";
+            if (! empty($sizes)) {
+                $sourceHtml .= " sizes=\"{$sizes}\"";
+            }
+            $sourceHtml .= '>';
+
+            $sources[] = $sourceHtml;
         }
 
-        // Use the last format as fallback (or original if no responsive images)
-        $fallbackFormat = end($sortedFormats);
-        $fallbackSrcset = $this->getSrcset($fallbackFormat);
-
-        if ($fallbackSrcset) {
-            $defaultAttributes['srcset'] = $fallbackSrcset;
-        }
-
-        $imgAttributes = array_merge($defaultAttributes, $attributes);
-        $imgAttributes = $this->applyPlaceholderStyle($imgAttributes, $injectPlaceholder);
-        $imgAttributesString = $this->attributesToString($imgAttributes);
-
-        // Generate picture element
-        if (empty($sources)) {
-            return "<img $imgAttributesString>";
-        }
-
-        $sourcesString = implode("\n    ", $sources);
-
-        return "<picture>\n    $sourcesString\n    <img $imgAttributesString>\n</picture>";
+        return $sources;
     }
 
     /**
@@ -278,6 +286,7 @@ trait ResponsiveImages
         }
 
         return $images
+            ->filter(fn ($img) => ! empty($img->url) && (int) $img->width > 0)
             ->sortByDesc('width')
             ->map(fn ($img) => $img->url.' '.$img->width.'w')
             ->implode(', ');

--- a/tests/Feature/ResponsiveImagesTest.php
+++ b/tests/Feature/ResponsiveImagesTest.php
@@ -276,13 +276,15 @@ it('clears responsive images via the trait', function () {
     expect($media->clearResponsiveImages())->toBe($media);
 });
 
-it('returns simple img html when only original format is available', function () {
+it('wraps the img in <picture> even when no responsive variants exist', function () {
     $file = UploadedFile::fake()->image('test.jpg', 800, 600);
     $media = MediaUploader::source($file)->upload();
 
     $html = $media->getPictureHtml();
-    expect($html)->toStartWith('<img ')
-        ->not->toContain('<picture>');
+    expect($html)->toStartWith('<picture>')
+        ->and($html)->toContain('<img ')
+        ->and($html)->not->toContain('<source')
+        ->and($html)->toEndWith('</picture>');
 });
 
 it('escapes html attributes when building img tag', function () {
@@ -480,15 +482,16 @@ it('returns getUrl for non-image when calling getResponsiveUrl', function () {
     expect($media->getResponsiveUrl(500, 'webp'))->toEqual($media->getUrl());
 });
 
-it('falls back to img tag when sources cannot be built', function () {
-    // Single non-priority format with no srcset (empty url) — degrades to plain <img>
+it('skips malformed <source> entries when their srcset is empty', function () {
+    // Degenerate responsive entry (empty url + width 0) — should not produce a <source>.
     $media = buildMediaWithResponsiveData([
         ['width' => 0, 'height' => 0, 'format' => 'webp', 'path' => '', 'url' => '', 'size' => 0],
     ]);
 
     $html = $media->getPictureHtml();
-    expect($html)->toStartWith('<img ')
-        ->not->toContain('<picture>');
+    expect($html)->toStartWith('<picture>')
+        ->and($html)->not->toContain('<source')
+        ->and($html)->toContain('<img ');
 });
 
 it('returns 0 dimensions when calculateImageDimensions fails', function () {


### PR DESCRIPTION
## Summary

`getPictureHtml()` had two related shape inconsistencies, both pre-existing on `main`, that were exposed while reviewing PR #16:

1. **Single-format responsive setups silently produced bare `<img>` instead of `<picture>`.** The default config (`formats=['webp']`) generates only WebP variants. The renderer reserved the "last format" as the inner `<img>` srcset, which left the source-list empty and dropped the `<picture>` wrapper. The output mixed WebP candidates into `<img srcset>` while `<img src>` still pointed at the original JPEG — semantically incoherent even though browsers tolerated it.
2. **Without any responsive variants the method silently delegated to `getSimpleImgHtml()`.** Callers got `<img>` in some states and `<picture>` in others, with no way to predict from the call site.

This PR consolidates `getPictureHtml()` around a single contract:

- **Always emits a `<picture>` wrapper.** Without responsive variants you get `<picture><img></picture>` — semantically equivalent to a bare `<img>`, but the markup shape is now predictable.
- **Every responsive format becomes its own `<source>`** (modern formats first). No more "last format reserved as fallback" — the inner `<img>` always points at the original file with its native width as a single `srcset` candidate. The fallback path stays width-aware even when no `<source>` matches.
- **`getSrcset()` filters degenerate entries** (empty URL or zero width) so malformed responsive-data records can't surface as `<source srcset=" 0w">` in the rendered output.
- **`getSimpleImgHtml()` is unchanged** and remains the explicit escape hatch for callers that need a bare `<img>` (email templates, embedded contexts).

## Example output (`formats=['webp']`, JPEG original)

Before:
```html
<img src=".../original.jpg" srcset=".../480.webp 480w, .../768.webp 768w, .../1280.webp 1280w">
```

After:
```html
<picture>
    <source type="image/webp" srcset=".../480.webp 480w, .../768.webp 768w, .../1280.webp 1280w" sizes="...">
    <img src=".../original.jpg" srcset=".../original.jpg 1920w">
</picture>
```

## Test plan

- [x] `./vendor/bin/pest` — 550/551 passing (1 network-dependent skip)
- [x] `./vendor/bin/phpstan analyse` — 0 errors
- [x] `./vendor/bin/pint --test` — clean
- [ ] Manual smoke: upload an image, run `php artisan queue:work` so responsive WebP variants land, render via `getPictureHtml()`; output is a `<picture>` with one `<source type="image/webp">` and an `<img>` pointing at the original JPEG with its native width as `srcset` candidate.
- [ ] Manual smoke: upload an image without responsive variants, render via `getPictureHtml()`; output is `<picture><img></picture>` (wrapper present, no `<source>`).
- [ ] Manual smoke: `getSimpleImgHtml()` still returns a bare `<img>` — unchanged.
- [ ] Manual smoke: configure `formats=['webp', 'avif']` and re-generate; render via `getPictureHtml()`; both formats appear as `<source>` elements (AVIF first by priority), `<img>` carries the original.

## Notes

- Behavior change on the rendered markup. Callers that parsed `getPictureHtml()` output assuming "either `<img>` or `<picture>`" must update to expect `<picture>` always. Callers that want bare `<img>` should use `getSimpleImgHtml()`.
- Should land before #16; that PR rebases cleanly onto this.
