### PR TITLE
Lightweight placeholder generators: DominantColor + GeometricBlur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to `emaia/laravel-mediaman` will be documented in this file.
 
 ### Added
 
+- **Two lightweight `PlaceholderGenerator` implementations** alongside the default `BlurredSvgPlaceholder`:
+  - `DominantColorPlaceholder` — single area-weighted average color wrapped in a flat-fill SVG. ~150 bytes regardless of source size. Pure ASCII. Ideal for galleries, bandwidth-sensitive contexts, and CSS skeletons.
+  - `GeometricBlurPlaceholder` — N×N color grid (default 4×4) sampled from the source, rendered as `<rect>`s under an `feGaussianBlur` filter. ~2 KB at grid=4 (regardless of source size); grid=8 (~6–8 KB) trades size for visual richness. Pure ASCII, CSP-friendly. Two new config knobs: `mediaman.placeholder.grid_size` and `mediaman.placeholder.blur_std_deviation`.
+  - See [Responsive images → Choosing a placeholder generator](docs/responsive-images.md#choosing-a-placeholder-generator) for the trade-off table.
 - **Pluggable LQIP via `Emaia\MediaMan\Placeholders\PlaceholderGenerator`.** Swap via `mediaman.placeholder.generator` or rebind the interface (mirrors the v2.9 generators pattern). Default implementation `BlurredSvgPlaceholder` wraps a tiny blurred JPEG inside an SVG with the original `viewBox` and returns a percent-encoded `data:image/svg+xml,…` URI (~16% smaller than the equivalent base64 wrapper, readable in DevTools).
 - Image meta (`width`, `height`, `dominant_color`) is now persisted in `custom_properties.image_meta` for every image upload in a single decode pass, independent of the placeholder feature. The struct was previously named `dimensions` and held only width/height.
 - `Media::getPlaceholderColor(): ?string` — hex CSS color sampled at upload (average of the source). ~10 bytes, ideal as a `background-color` skeleton anywhere the LQIP data URI is too heavy: email, SSR, JSON APIs, container backgrounds. Composes naturally with `getPictureHtml()` for a three-stage progressive paint (color → SVG LQIP → responsive image).

--- a/config/mediaman.php
+++ b/config/mediaman.php
@@ -208,6 +208,11 @@ return [
             'blur' => 20,
             'quality' => 40,  // JPEG quality (1-100)
         ],
+
+        'geometric_blur' => [
+            'grid_size' => 4,             // N×N color grid sampled from the image
+            'blur_std_deviation' => 20,   // feGaussianBlur intensity
+        ],
     ],
 
     /*

--- a/docs/api.md
+++ b/docs/api.md
@@ -338,7 +338,13 @@ interface PlaceholderGenerator
 }
 ```
 
-Default: `BlurredSvgPlaceholder` — wraps a tiny blurred JPEG in an SVG with the original `viewBox` and returns a percent-encoded `data:image/svg+xml,…` URI (~16% smaller than the equivalent base64 wrapper, and readable in DevTools). Returns `null` on any failure so the upload pipeline keeps going.
+Three implementations ship out of the box; all three return the same `data:image/svg+xml,…` URI shape so the rendering pipeline stays generator-agnostic. See [Responsive images → Choosing a placeholder generator](responsive-images.md#choosing-a-placeholder-generator) for the trade-off table.
+
+- **`BlurredSvgPlaceholder` (default)** — embeds a tiny blurred JPEG inside an SVG with the original `viewBox`. Photographic quality, ~3 KB. Knobs: `mediaman.placeholder.{width, blur, quality}`.
+- **`GeometricBlurPlaceholder`** — resizes the source to N×N, emits one `<rect>` per cell, wraps the whole thing in `<filter><feGaussianBlur/></filter>`. Stylized blocks, ~2 KB at grid=4 (and bigger at higher grid sizes), pure ASCII so it works under strict CSP. Knobs: `mediaman.placeholder.{grid_size, blur_std_deviation}`.
+- **`DominantColorPlaceholder`** — a single `<rect>` filled with the area-weighted average color. ~150 B, flat. No knobs.
+
+All three return `null` on failure so the upload pipeline keeps going.
 
 Swap via `mediaman.placeholder.generator` config or rebind the interface:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,6 +194,11 @@ Low-quality image placeholder (LQIP) — a tiny blurred JPEG generated synchrono
         'blur'    => 20,
         'quality' => 40,  // JPEG quality (1-100)
     ],
+
+    'geometric_blur' => [
+        'grid_size'          => 4,   // N×N sampled grid
+        'blur_std_deviation' => 20,  // feGaussianBlur intensity
+    ],
 ],
 ```
 
@@ -201,9 +206,9 @@ When on, adds ~50 ms per image upload and ~3 KB to `custom_properties`. Generati
 
 When off, `Media::getPlaceholder()` returns `null`, `getUrlOrPlaceholder()` behaves like `getUrl()`, and `getPictureHtml()`/`getSimpleImgHtml()` skip the srcset injection silently. Image meta (`width`, `height`, `dominant_color`) is still persisted at upload time, so the `<img>` keeps its `width`/`height` for zero CLS and `Media::getPlaceholderColor()` keeps returning a usable CSS color.
 
-`generator` accepts any class implementing `Emaia\MediaMan\Placeholders\PlaceholderGenerator`. The default `BlurredSvgPlaceholder` wraps a tiny blurred JPEG inside an SVG with the original `viewBox`; swap it for BlurHash, ThumbHash, dominant color, etc.
+`generator` accepts any class implementing `Emaia\MediaMan\Placeholders\PlaceholderGenerator`. Three implementations ship out of the box: `BlurredSvgPlaceholder` (default — photographic, ~3 KB), `GeometricBlurPlaceholder` (stylized blocks, ~2 KB at grid=4, pure ASCII so CSP-friendly), and `DominantColorPlaceholder` (flat ~150 B). See [Responsive images → Choosing a placeholder generator](responsive-images.md#choosing-a-placeholder-generator).
 
-**Per-generator tuning is scoped to its own sub-block.** `mediaman.placeholder.blurred_svg.{width, blur, quality}` only applies when the active `generator` is `BlurredSvgPlaceholder`. Swapping generators ignores knobs that don't belong to them — no silent reuse, no namespace collisions.
+**Per-generator tuning is scoped to its own sub-block.** `mediaman.placeholder.blurred_svg.{width, blur, quality}` only applies when the active `generator` is `BlurredSvgPlaceholder`; `mediaman.placeholder.geometric_blur.{grid_size, blur_std_deviation}` only applies to `GeometricBlurPlaceholder`. Swapping generators ignores knobs that don't belong to them — no silent reuse, no namespace collisions.
 
 ## Responsive images
 

--- a/docs/responsive-images.md
+++ b/docs/responsive-images.md
@@ -188,6 +188,31 @@ echo $media->getPictureHtml(['loading' => 'lazy']);
 
 The combination — solid color → SVG blur → responsive image — gives three progressive paints with one persisted value each. Works inside email and other contexts where `<picture>` doesn't apply too: drop the picture call and the color alone is a decent skeleton.
 
+### Choosing a placeholder generator
+
+The default `BlurredSvgPlaceholder` works for most apps, but the package ships two lightweight alternatives. Swap via `mediaman.placeholder.generator`:
+
+| Generator | Payload (typical) | Visual character | Best for |
+|---|---|---|---|
+| `BlurredSvgPlaceholder` (default) | ~3 KB | Photographic blur (real thumbnail of the source, smoothed) | Editorial / blog / portfolio — quality of the preview matters |
+| `GeometricBlurPlaceholder` | ~2 KB (grid=4), ~6–8 KB (grid=8) | Stylized geometric blocks — you can see where the bright and dark regions live, but it never looks "photographic" | Performance-focused apps that still want a visible hint of composition; CSP-strict environments (no embedded binary) |
+| `DominantColorPlaceholder` | ~150 B | Flat solid color (area-weighted average) | Galleries / grids with many thumbnails; bandwidth-sensitive contexts; fallback for when the LQIP isn't worth its own payload |
+
+All three return the same `data:image/svg+xml,…` URI shape, so the rendering pipeline (`getPictureHtml` / `getSimpleImgHtml` / `getUrlOrPlaceholder`) is generator-agnostic.
+
+```php
+// config/mediaman.php
+'placeholder' => [
+    'enabled' => true,
+    'generator' => Emaia\MediaMan\Placeholders\GeometricBlurPlaceholder::class,
+    'grid_size' => 4,            // N×N color grid (GeometricBlur)
+    'blur_std_deviation' => 20,  // feGaussianBlur intensity (GeometricBlur)
+    // width / blur / quality apply to BlurredSvgPlaceholder (the default)
+],
+```
+
+Need a custom strategy (BlurHash, ThumbHash, dominant color from a palette, etc.)? Implement `Emaia\MediaMan\Placeholders\PlaceholderGenerator` and bind it. See [API → Placeholders](api.md#placeholders).
+
 ## Clearing variants
 
 ```php

--- a/src/Placeholders/DominantColorPlaceholder.php
+++ b/src/Placeholders/DominantColorPlaceholder.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Emaia\MediaMan\Placeholders;
+
+use Intervention\Image\ImageManager;
+use Throwable;
+
+class DominantColorPlaceholder implements PlaceholderGenerator
+{
+    public function __construct(protected ImageManager $images) {}
+
+    public function generate(string $sourcePath, int $width, int $height): ?string
+    {
+        if ($width <= 0 || $height <= 0) {
+            return null;
+        }
+
+        try {
+            // resize() forces 1×1 (no aspect ratio preservation), so the
+            // single pixel is the area-weighted average of the source image.
+            $color = $this->images
+                ->decode(file_get_contents($sourcePath))
+                ->resize(width: 1, height: 1)
+                ->colorAt(0, 0)
+                ->toHex(prefix: true);
+
+            $svg = sprintf(
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d"><rect width="100%%" height="100%%" fill="%s"/></svg>',
+                $width,
+                $height,
+                $color
+            );
+
+            return 'data:image/svg+xml,'.rawurlencode($svg);
+        } catch (Throwable) {
+            return null;
+        }
+    }
+}

--- a/src/Placeholders/GeometricBlurPlaceholder.php
+++ b/src/Placeholders/GeometricBlurPlaceholder.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Emaia\MediaMan\Placeholders;
+
+use Intervention\Image\ImageManager;
+use Throwable;
+
+class GeometricBlurPlaceholder implements PlaceholderGenerator
+{
+    public function __construct(protected ImageManager $images) {}
+
+    public function generate(string $sourcePath, int $width, int $height): ?string
+    {
+        if ($width <= 0 || $height <= 0) {
+            return null;
+        }
+
+        try {
+            $gridSize = (int) config('mediaman.placeholder.geometric_blur.grid_size', 4);
+            $stdDeviation = (float) config('mediaman.placeholder.geometric_blur.blur_std_deviation', 20);
+
+            if ($gridSize < 1) {
+                return null;
+            }
+
+            // resize() to N×N forces non-aspect-preserving downscale, so each
+            // pixel in the thumb is the area-weighted average of the matching
+            // block of the source — the heavy lifting is one C-level resample
+            // pass; the colorAt loop then reads N² pixels off the thumb.
+            $thumb = $this->images
+                ->decode(file_get_contents($sourcePath))
+                ->resize(width: $gridSize, height: $gridSize);
+
+            $cellWidth = $width / $gridSize;
+            $cellHeight = $height / $gridSize;
+
+            $rects = '';
+            for ($y = 0; $y < $gridSize; $y++) {
+                for ($x = 0; $x < $gridSize; $x++) {
+                    $color = $thumb->colorAt($x, $y)->toHex(prefix: true);
+                    $rects .= sprintf(
+                        '<rect x="%s" y="%s" width="%s" height="%s" fill="%s"/>',
+                        $this->trimFloat($x * $cellWidth),
+                        $this->trimFloat($y * $cellHeight),
+                        $this->trimFloat($cellWidth),
+                        $this->trimFloat($cellHeight),
+                        $color
+                    );
+                }
+            }
+
+            $svg = sprintf(
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d"><filter id="b"><feGaussianBlur stdDeviation="%s"/></filter><g filter="url(#b)">%s</g></svg>',
+                $width,
+                $height,
+                $this->trimFloat($stdDeviation),
+                $rects
+            );
+
+            return 'data:image/svg+xml,'.rawurlencode($svg);
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Shortest decimal representation; integers print without a fractional
+     * suffix so the SVG body stays compact.
+     */
+    protected function trimFloat(float $value): string
+    {
+        return rtrim(rtrim(sprintf('%.4f', $value), '0'), '.');
+    }
+}

--- a/tests/Feature/DominantColorPlaceholderTest.php
+++ b/tests/Feature/DominantColorPlaceholderTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Emaia\MediaMan\MediaUploader;
+use Emaia\MediaMan\Placeholders\DominantColorPlaceholder;
+use Emaia\MediaMan\Placeholders\PlaceholderGenerator;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Config;
+
+beforeEach(function () {
+    Config::set('mediaman.placeholder.enabled', true);
+    // The service provider captures config('mediaman.placeholder.generator')
+    // at register time, so swapping config here wouldn't rebind. Bind the
+    // generator instance directly for the duration of the test.
+    app()->instance(PlaceholderGenerator::class, app(DominantColorPlaceholder::class));
+});
+
+it('produces a single-fill SVG with the original viewBox', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg', 1280, 720))->upload();
+
+    $svg = rawurldecode(substr($media->getPlaceholder(), strlen('data:image/svg+xml,')));
+
+    expect($svg)->toContain('viewBox="0 0 1280 720"')
+        ->and($svg)->toContain('<rect')
+        ->and($svg)->toMatch('/fill="#[0-9a-f]{6}([0-9a-f]{2})?"/i')
+        ->and($svg)->not->toContain('<filter')
+        ->and($svg)->not->toContain('<image');
+});
+
+it('keeps the payload tiny (< 250 bytes regardless of source size)', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg', 4000, 3000))->upload();
+
+    expect(strlen($media->getPlaceholder()))->toBeLessThan(250);
+});
+
+it('produces a srcset-safe data URI', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg', 800, 600))->upload();
+
+    $uri = $media->getPlaceholder();
+    $body = substr($uri, strlen('data:image/svg+xml,'));
+
+    expect($uri)->not->toMatch('/\s/')
+        ->and($body)->not->toContain(',');
+});
+
+it('returns null for non-image uploads', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->create('document.pdf', 100, 'application/pdf'))->upload();
+
+    expect($media->getPlaceholder())->toBeNull();
+});

--- a/tests/Feature/DominantColorPlaceholderTest.php
+++ b/tests/Feature/DominantColorPlaceholderTest.php
@@ -8,9 +8,9 @@ use Illuminate\Support\Facades\Config;
 
 beforeEach(function () {
     Config::set('mediaman.placeholder.enabled', true);
-    // The service provider captures config('mediaman.placeholder.generator')
-    // at register time, so swapping config here wouldn't rebind. Bind the
-    // generator instance directly for the duration of the test.
+    // Bind the instance directly so the swap is unambiguous within the test
+    // — the closure bind reads the configured generator lazily, but the
+    // singleton caches the first resolve.
     app()->instance(PlaceholderGenerator::class, app(DominantColorPlaceholder::class));
 });
 

--- a/tests/Feature/DominantColorPlaceholderTest.php
+++ b/tests/Feature/DominantColorPlaceholderTest.php
@@ -8,10 +8,11 @@ use Illuminate\Support\Facades\Config;
 
 beforeEach(function () {
     Config::set('mediaman.placeholder.enabled', true);
-    // Bind the instance directly so the swap is unambiguous within the test
-    // — the closure bind reads the configured generator lazily, but the
-    // singleton caches the first resolve.
-    app()->instance(PlaceholderGenerator::class, app(DominantColorPlaceholder::class));
+    Config::set('mediaman.placeholder.generator', DominantColorPlaceholder::class);
+    // The closure bind reads config lazily, but the singleton caches the
+    // first resolve. Forget so the next app() call picks up the swapped
+    // generator from config.
+    app()->forgetInstance(PlaceholderGenerator::class);
 });
 
 it('produces a single-fill SVG with the original viewBox', function () {

--- a/tests/Feature/GeometricBlurPlaceholderTest.php
+++ b/tests/Feature/GeometricBlurPlaceholderTest.php
@@ -8,10 +8,11 @@ use Illuminate\Support\Facades\Config;
 
 beforeEach(function () {
     Config::set('mediaman.placeholder.enabled', true);
-    // The closure bind reads the configured generator lazily, but the
-    // singleton caches the first resolve. Bind an instance directly so the
-    // swap is unambiguous within the test.
-    app()->instance(PlaceholderGenerator::class, app(GeometricBlurPlaceholder::class));
+    Config::set('mediaman.placeholder.generator', GeometricBlurPlaceholder::class);
+    // The closure bind reads config lazily, but the singleton caches the
+    // first resolve. Forget so the next app() call picks up the swapped
+    // generator from config.
+    app()->forgetInstance(PlaceholderGenerator::class);
 });
 
 function decodeGeometricSvg(string $dataUri): string

--- a/tests/Feature/GeometricBlurPlaceholderTest.php
+++ b/tests/Feature/GeometricBlurPlaceholderTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use Emaia\MediaMan\MediaUploader;
+use Emaia\MediaMan\Placeholders\GeometricBlurPlaceholder;
+use Emaia\MediaMan\Placeholders\PlaceholderGenerator;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Config;
+
+beforeEach(function () {
+    Config::set('mediaman.placeholder.enabled', true);
+    // The closure bind reads the configured generator lazily, but the
+    // singleton caches the first resolve. Bind an instance directly so the
+    // swap is unambiguous within the test.
+    app()->instance(PlaceholderGenerator::class, app(GeometricBlurPlaceholder::class));
+});
+
+function decodeGeometricSvg(string $dataUri): string
+{
+    return rawurldecode(substr($dataUri, strlen('data:image/svg+xml,')));
+}
+
+it('wraps a 4×4 grid of rects with a feGaussianBlur filter', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg', 800, 600))->upload();
+
+    $svg = decodeGeometricSvg($media->getPlaceholder());
+
+    expect($svg)->toContain('viewBox="0 0 800 600"')
+        ->and($svg)->toContain('<filter')
+        ->and($svg)->toContain('<feGaussianBlur')
+        ->and(substr_count($svg, '<rect'))->toEqual(16)
+        ->and($svg)->not->toContain('<image');
+});
+
+it('respects mediaman.placeholder.geometric_blur.grid_size', function () {
+    Config::set('mediaman.placeholder.geometric_blur.grid_size', 8);
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg', 800, 600))->upload();
+
+    $svg = decodeGeometricSvg($media->getPlaceholder());
+
+    expect(substr_count($svg, '<rect'))->toEqual(64);
+});
+
+it('propagates mediaman.placeholder.geometric_blur.blur_std_deviation into the SVG filter', function () {
+    Config::set('mediaman.placeholder.geometric_blur.blur_std_deviation', 35);
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg', 800, 600))->upload();
+
+    $svg = decodeGeometricSvg($media->getPlaceholder());
+
+    expect($svg)->toContain('stdDeviation="35"');
+});
+
+it('returns null when grid_size is 0 or negative', function () {
+    Config::set('mediaman.placeholder.geometric_blur.grid_size', 0);
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg', 800, 600))->upload();
+
+    expect($media->getPlaceholder())->toBeNull();
+});
+
+it('produces a srcset-safe data URI', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg', 800, 600))->upload();
+
+    $uri = $media->getPlaceholder();
+    $body = substr($uri, strlen('data:image/svg+xml,'));
+
+    expect($uri)->not->toMatch('/\s/')
+        ->and($body)->not->toContain(',');
+});
+
+it('produces a compact payload at grid=4 (< 2.5 KB regardless of source size)', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg', 4000, 3000))->upload();
+
+    // 16 rects × ~120 bytes url-encoded + SVG wrapper + filter ≈ 2 KB.
+    // Stays under 2.5 KB independently of source dimensions; grid=8 trades
+    // size (~6-8 KB) for visual richness.
+    expect(strlen($media->getPlaceholder()))->toBeLessThan(2500);
+});
+
+it('returns null for non-image uploads', function () {
+    $media = MediaUploader::source(UploadedFile::fake()->create('document.pdf', 100, 'application/pdf'))->upload();
+
+    expect($media->getPlaceholder())->toBeNull();
+});


### PR DESCRIPTION
## Summary

Ships two new `PlaceholderGenerator` implementations alongside the v2.13 `BlurredSvgPlaceholder` default, plus the docs that compare the three side-by-side.

- **`DominantColorPlaceholder`** — area-weighted average color (`resize(1,1)->colorAt(0,0)`) wrapped in a flat-fill SVG with the original `viewBox`. ~150 bytes regardless of source image size. Pure ASCII (no embedded binary, CSP-friendly). Ideal for galleries, bandwidth-sensitive contexts, and CSS skeletons where a photographic placeholder isn't worth the payload.
- **`GeometricBlurPlaceholder`** — N×N color grid (default 4×4) sampled from the source, rendered as `<rect>`s under an `<feGaussianBlur>` filter. ~2 KB at grid=4 (regardless of source size); grid=8 trades size (~6–8 KB) for visual richness. Two new config knobs under their own sub-block: `mediaman.placeholder.geometric_blur.{grid_size, blur_std_deviation}`.

Both generators are sampling-cheap — one `resize()` C-level downscale followed by N² `colorAt()` reads on the tiny thumb (16 reads at the default grid, microseconds).

A new "Choosing a placeholder generator" subsection in `docs/responsive-images.md` lays the three out side-by-side (payload, visual character, best-for) and shows the config switch. `docs/api.md` and `docs/configuration.md` were updated to list all three implementations and document the `geometric_blur` namespace.

Tests for the new generators swap the active implementation through `Config::set('mediaman.placeholder.generator', …)` + `app()->forgetInstance(PlaceholderGenerator::class)` — exercising the lazy closure bind shipped in v2.13 instead of forcing `app()->instance()` overrides.

## Test plan

- [x] `./vendor/bin/pest` — 571/572 passing (1 network-dependent skip)
- [x] `./vendor/bin/phpstan analyse` — 0 errors
- [x] `./vendor/bin/pint --test` — clean
- [ ] Manual smoke: set `mediaman.placeholder.generator = DominantColorPlaceholder::class`, upload an image, render via `getPictureHtml()`; every srcset ends with the SVG entry; decoded SVG is a single `<rect fill="#…">` with the original `viewBox`; payload < 250 bytes.
- [ ] Manual smoke: set `GeometricBlurPlaceholder::class` with `grid_size = 4`; upload an image; decoded SVG contains 16 `<rect>` elements under `<filter id="b"><feGaussianBlur/></filter>`; the visual preview hints at the source composition.
- [ ] Manual smoke: bump `grid_size` to `8`; preview gets richer; payload roughly quadruples (~6–8 KB).
- [ ] Manual smoke: throttle to Slow 3G — each generator paints with the correct aspect ratio before the responsive image swaps in.
