### PR TITLE
Add mediaman:generate-conversions command for batch regeneration (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `emaia/laravel-mediaman` will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `mediaman:generate-conversions` artisan command — generate (or regenerate) registered conversions for existing media. Required `--conversion=thumb,cover` lists one or more registered names (validated against the `ConversionRegistry`; unknown names short-circuit with a clear error). Optional `--media=1,3,5..10` filters by id (individual values and ranges), `--collection=avatars` filters by collection name. `--force` overwrites existing conversion files (default skips when the file is already on disk). `--queue` dispatches each item as a `PerformConversions` job instead of running synchronously. Confirmation prompt fires when the operation count (`media × conversions`) crosses 100. Output is a progress bar + per-item log + final summary (processed / queued / failed). Fills the gap between `mediaman:generate-responsive` (responsive variants only) and the common "I changed a conversion definition and want it re-applied to all media" workflow. See [Commands → Generate conversions](docs/commands.md#generate-conversions).
+
 ### Changed
 
 - `mediaman:responsive-stats` output now follows the same `php artisan about`-style layout adopted by `mediaman:doctor` in v2.16 — section headers + `twoColumnDetail` rows joined by dots-filler, colored status icons embedded in the value column. The information surfaced is identical; only the visual layout changes.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6,6 +6,7 @@
 - [Doctor (health check)](#doctor-health-check)
 - [Clean orphaned files](#clean-orphaned-files)
 - [Rotate media paths after APP_KEY rotation](#rotate-media-paths-after-app_key-rotation)
+- [Generate conversions](#generate-conversions)
 - [Generate responsive images](#generate-responsive-images)
 - [Clear responsive images](#clear-responsive-images)
 - [Responsive images stats](#responsive-images-stats)
@@ -120,6 +121,36 @@ php artisan mediaman:rotate-paths --old-key="$OLD_KEY" --force --media=42
 ```
 
 The command is idempotent: re-runs against already-migrated media report them as "already migrated" and skip. See [Security → APP_KEY rotation](security.md#app_key-rotation) for context.
+
+## Generate conversions
+
+Generate (or regenerate) registered conversions for existing media. Useful after changing a conversion definition (e.g. you tweaked the closure for `thumb` and want all stored thumbnails refreshed) or backfilling a newly-registered conversion for historical media.
+
+```bash
+php artisan mediaman:generate-conversions --conversion=thumb,cover
+```
+
+The `--conversion` flag is required. Names are validated against the `ConversionRegistry` — unknown names short-circuit with a clear error before any work starts.
+
+Filters:
+
+| Flag                   | Effect                                                                                                            |
+|------------------------|-------------------------------------------------------------------------------------------------------------------|
+| `--media=1,3,5..10`    | Restrict to specific media ids; supports comma-separated values and ranges (`from..to`). Mix freely (`1,3..5,9`). |
+| `--collection=avatars` | Restrict to media attached to a named collection.                                                                 |
+
+Behavior:
+
+| Flag      | Default | Effect                                                                                                                                              |
+|-----------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--force` | off     | Overwrite existing conversion files. Default skips when the target already exists on disk.                                                          |
+| `--queue` | off     | Dispatch each item as a `PerformConversions` job instead of running synchronously. Useful for large catalogs where you don't want to block the CLI. |
+
+A confirmation prompt fires when the operation count (`media × conversions`) crosses 100, so a typo in `--media` doesn't silently start thousands of jobs.
+
+Output is a progress bar + per-item log line (`Processed: name` or `Queued: name`) + a final summary (`N media item(s) processed.` or `N conversion job(s) queued.`, with `(M failed)` appended when sync mode encountered errors).
+
+Fills the gap between [Generate responsive images](#generate-responsive-images) (responsive variants only, no individual conversion names) and the manual "loop through `Media::chunk()` and call `(new ImageManipulator)->manipulate(...)`" pattern.
 
 ## Generate responsive images
 

--- a/src/Console/Commands/GenerateConversionsCommand.php
+++ b/src/Console/Commands/GenerateConversionsCommand.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Emaia\MediaMan\Console\Commands;
+
+use Emaia\MediaMan\ConversionRegistry;
+use Emaia\MediaMan\ImageManipulator;
+use Emaia\MediaMan\Jobs\PerformConversions;
+use Emaia\MediaMan\Models\Media;
+use Illuminate\Console\Command;
+
+class GenerateConversionsCommand extends Command
+{
+    protected $signature = 'mediaman:generate-conversions
+                            {--conversion= : Required. Comma-separated conversion names (e.g. "thumb,cover")}
+                            {--media= : Comma-separated IDs and/or ranges (e.g. "1,3,5..10")}
+                            {--collection= : Filter by collection name}
+                            {--force : Overwrite existing conversion files (default: skip if exists)}
+                            {--queue : Dispatch as queued jobs}';
+
+    protected $description = 'Generate image conversions for existing media';
+
+    public function handle(): int
+    {
+        if (empty($this->option('conversion'))) {
+            $this->error('The --conversion option is required.');
+
+            return self::FAILURE;
+        }
+
+        $conversionNames = array_map('trim', explode(',', $this->option('conversion')));
+
+        $registry = app(ConversionRegistry::class);
+        $invalid = array_filter($conversionNames, fn ($name) => ! $registry->exists($name));
+
+        if (! empty($invalid)) {
+            $this->error('Unknown conversion(s): '.implode(', ', $invalid));
+
+            return self::FAILURE;
+        }
+
+        $query = Media::query()->where('mime_type', 'like', 'image/%');
+
+        if ($mediaOption = $this->option('media')) {
+            $ids = $this->parseMediaIds($mediaOption);
+
+            if (empty($ids)) {
+                $this->error('Invalid --media value.');
+
+                return self::FAILURE;
+            }
+
+            $query->whereIn('id', $ids);
+        }
+
+        if ($collection = $this->option('collection')) {
+            $query->whereHas('collections', function ($q) use ($collection) {
+                $q->where('name', $collection);
+            });
+        }
+
+        $mediaItems = $query->get();
+
+        if ($mediaItems->isEmpty()) {
+            $this->info('No media items found to process.');
+
+            return self::SUCCESS;
+        }
+
+        $total = $mediaItems->count();
+        $convCount = count($conversionNames);
+
+        if ($total * $convCount > 100 && ! $this->confirm("Will process {$total} media item(s) × {$convCount} conversion(s) = ".($total * $convCount).' operations. Continue?')) {
+            $this->info('Cancelled.');
+
+            return self::SUCCESS;
+        }
+
+        $this->section('Generate conversions');
+
+        $this->statusLine('Conversions', 'info', implode(', ', $conversionNames));
+        $this->statusLine('Media items', 'info', (string) $total);
+        $this->newLine();
+
+        if ($this->option('queue')) {
+            $this->processQueued($mediaItems, $conversionNames);
+
+            return self::SUCCESS;
+        }
+
+        $this->processInline($mediaItems, $conversionNames, (bool) $this->option('force'));
+
+        return self::SUCCESS;
+    }
+
+    protected function processQueued($mediaItems, array $conversionNames): void
+    {
+        $count = $mediaItems->count();
+
+        foreach ($mediaItems as $media) {
+            PerformConversions::dispatch($media, $conversionNames);
+        }
+
+        $this->statusLine('Dispatched', 'ok', "{$count} (queued)");
+    }
+
+    protected function processInline($mediaItems, array $conversionNames, bool $force): void
+    {
+        $manipulator = app(ImageManipulator::class);
+        $processed = 0;
+        $skipped = 0;
+        $failures = [];
+
+        foreach ($mediaItems as $media) {
+            $existing = [];
+            $needed = [];
+
+            foreach ($conversionNames as $conv) {
+                if (! $force && $media->hasConversion($conv)) {
+                    $existing[] = $conv;
+                } else {
+                    $needed[] = $conv;
+                }
+            }
+
+            $skippedHere = count($existing);
+            $skipped += $skippedHere;
+
+            if (empty($needed)) {
+                continue;
+            }
+
+            try {
+                $manipulator->manipulate($media, $needed, false);
+                $processed++;
+            } catch (\Exception $e) {
+                $failures[] = ['id' => $media->getKey(), 'name' => $media->name, 'error' => $e->getMessage()];
+            }
+        }
+
+        if ($processed > 0) {
+            $this->statusLine('Processed', 'ok', (string) $processed);
+        }
+
+        if ($skipped > 0) {
+            $this->statusLine('Skipped (already exist)', 'warn', (string) $skipped);
+        }
+
+        if (! empty($failures)) {
+            $this->statusLine('Failed', 'error', (string) count($failures));
+
+            foreach ($failures as $f) {
+                $this->components->twoColumnDetail(
+                    "  #{$f['id']} {$f['name']}",
+                    "<fg=red>✗</> {$f['error']}"
+                );
+            }
+        }
+
+        if ($processed === 0 && $skipped === 0 && empty($failures)) {
+            $this->statusLine('Result', 'info', 'nothing to do');
+        }
+    }
+
+    /**
+     * Parse --media value into an array of IDs. Supports comma-separated
+     * individual IDs ("1,3,5") and ranges ("1..10"), or a mix ("1,3..5").
+     */
+    protected function parseMediaIds(string $value): array
+    {
+        $ids = [];
+
+        foreach (explode(',', $value) as $part) {
+            $part = trim($part);
+
+            if ($part === '') {
+                continue;
+            }
+
+            if (str_contains($part, '..')) {
+                [$from, $to] = explode('..', $part);
+                $from = (int) $from;
+                $to = (int) $to;
+
+                if ($from <= 0 || $to <= 0 || $from > $to) {
+                    return [];
+                }
+
+                for ($i = $from; $i <= $to; $i++) {
+                    $ids[] = $i;
+                }
+            } else {
+                $id = (int) $part;
+
+                if ($id <= 0) {
+                    return [];
+                }
+
+                $ids[] = $id;
+            }
+        }
+
+        return $ids;
+    }
+
+    protected function section(string $title): void
+    {
+        $this->newLine();
+        $this->components->twoColumnDetail('  <fg=green;options=bold>'.$title.'</>');
+    }
+
+    protected function statusLine(string $label, string $level, string $value): void
+    {
+        $icon = match ($level) {
+            'ok' => '<fg=green>✓</>',
+            'warn' => '<fg=yellow>⚠</>',
+            'error' => '<fg=red>✗</>',
+            default => '<fg=gray>·</>',
+        };
+
+        $this->components->twoColumnDetail($label, "{$icon} {$value}");
+    }
+}

--- a/src/MediaManServiceProvider.php
+++ b/src/MediaManServiceProvider.php
@@ -5,6 +5,7 @@ namespace Emaia\MediaMan;
 use Emaia\MediaMan\Console\Commands\CleanCommand;
 use Emaia\MediaMan\Console\Commands\ClearResponsiveImagesCommand;
 use Emaia\MediaMan\Console\Commands\DoctorCommand;
+use Emaia\MediaMan\Console\Commands\GenerateConversionsCommand;
 use Emaia\MediaMan\Console\Commands\GenerateResponsiveImagesCommand;
 use Emaia\MediaMan\Console\Commands\PublishCommand;
 use Emaia\MediaMan\Console\Commands\PublishConfigCommand;
@@ -80,6 +81,7 @@ class MediaManServiceProvider extends ServiceProvider
                 PublishConfigCommand::class,
                 PublishMigrationCommand::class,
                 GenerateResponsiveImagesCommand::class,
+                GenerateConversionsCommand::class,
                 ClearResponsiveImagesCommand::class,
                 ResponsiveImagesStatsCommand::class,
                 CleanCommand::class,

--- a/tests/Feature/Commands/GenerateConversionsCommandTest.php
+++ b/tests/Feature/Commands/GenerateConversionsCommandTest.php
@@ -1,0 +1,221 @@
+<?php
+
+use Emaia\MediaMan\Facades\Conversion;
+use Emaia\MediaMan\Jobs\PerformConversions;
+use Emaia\MediaMan\MediaUploader;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Format;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+function captureGenerateConversionsOutput(array $options = []): string
+{
+    $output = new BufferedOutput;
+    Artisan::call('mediaman:generate-conversions', $options, $output);
+
+    return $output->fetch();
+}
+
+it('exits with error when --conversion is missing', function () {
+    $this->artisan('mediaman:generate-conversions')
+        ->expectsOutputToContain('--conversion option is required')
+        ->assertExitCode(1);
+});
+
+it('exits with error for unknown conversion names', function () {
+    $this->artisan('mediaman:generate-conversions', ['--conversion' => 'nonexistent'])
+        ->expectsOutputToContain('Unknown conversion')
+        ->assertExitCode(1);
+});
+
+it('registers a conversion and generates it for a media item', function () {
+    Conversion::register('thumb', function ($image) {
+        return $image->resize(200, 200)->encodeUsingFormat(Format::JPEG);
+    });
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $out = captureGenerateConversionsOutput(['--conversion' => 'thumb', '--force' => true]);
+
+    expect($out)->toContain('Generate conversions', 'Conversions', 'thumb', 'Media items', 'Processed', '1');
+
+    $path = $media->fresh()->getPath('thumb');
+    expect(Storage::disk(self::DEFAULT_DISK)->exists($path))->toBeTrue();
+});
+
+it('skips existing conversions without --force', function () {
+    Conversion::register('thumb', function ($image) {
+        return $image->resize(200, 200)->encodeUsingFormat(Format::JPEG);
+    });
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    captureGenerateConversionsOutput(['--conversion' => 'thumb', '--force' => true]);
+
+    $mtimeBefore = Storage::disk(self::DEFAULT_DISK)->lastModified($media->getPath('thumb'));
+
+    $out = captureGenerateConversionsOutput(['--conversion' => 'thumb']);
+
+    expect($out)->toContain('Skipped (already exist)', '1');
+
+    $mtimeAfter = Storage::disk(self::DEFAULT_DISK)->lastModified($media->getPath('thumb'));
+
+    expect($mtimeAfter)->toEqual($mtimeBefore);
+});
+
+it('overwrites existing conversions with --force', function () {
+    Conversion::register('thumb', function ($image) {
+        return $image->resize(200, 200)->encodeUsingFormat(Format::JPEG);
+    });
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    captureGenerateConversionsOutput(['--conversion' => 'thumb', '--force' => true]);
+
+    sleep(1);
+    $mtimeBefore = Storage::disk(self::DEFAULT_DISK)->lastModified($media->getPath('thumb'));
+
+    $out = captureGenerateConversionsOutput(['--conversion' => 'thumb', '--force' => true]);
+
+    expect($out)->toContain('Processed', '1');
+
+    $mtimeAfter = Storage::disk(self::DEFAULT_DISK)->lastModified($media->getPath('thumb'));
+
+    expect($mtimeAfter)->not->toEqual($mtimeBefore);
+});
+
+it('filters by --media with individual IDs', function () {
+    Conversion::register('thumb', function ($image) {
+        return $image->resize(200, 200);
+    });
+
+    $m1 = MediaUploader::source(UploadedFile::fake()->image('a.jpg'))->useName('a')->upload();
+    MediaUploader::source(UploadedFile::fake()->image('b.jpg'))->useName('b')->upload();
+
+    $out = captureGenerateConversionsOutput([
+        '--conversion' => 'thumb',
+        '--force' => true,
+        '--media' => (string) $m1->id,
+    ]);
+
+    expect($out)->toContain('Media items', 'Processed', '1');
+});
+
+it('filters by --media with range syntax', function () {
+    Conversion::register('thumb', function ($image) {
+        return $image->resize(200, 200);
+    });
+
+    MediaUploader::source(UploadedFile::fake()->image('a.jpg'))->useName('a')->upload();
+    $m2 = MediaUploader::source(UploadedFile::fake()->image('b.jpg'))->useName('b')->upload();
+    $m3 = MediaUploader::source(UploadedFile::fake()->image('c.jpg'))->useName('c')->upload();
+
+    $out = captureGenerateConversionsOutput([
+        '--conversion' => 'thumb',
+        '--force' => true,
+        '--media' => "{$m2->id}..{$m3->id}",
+    ]);
+
+    expect($out)->toContain('Media items', 'Processed', '2');
+});
+
+it('filters by --media with mixed IDs and ranges', function () {
+    Conversion::register('thumb', function ($image) {
+        return $image->resize(200, 200);
+    });
+
+    $m1 = MediaUploader::source(UploadedFile::fake()->image('a.jpg'))->useName('a')->upload();
+    $m2 = MediaUploader::source(UploadedFile::fake()->image('b.jpg'))->useName('b')->upload();
+    $m3 = MediaUploader::source(UploadedFile::fake()->image('c.jpg'))->useName('c')->upload();
+
+    $out = captureGenerateConversionsOutput([
+        '--conversion' => 'thumb',
+        '--force' => true,
+        '--media' => "{$m1->id},{$m2->id}..{$m3->id}",
+    ]);
+
+    expect($out)->toContain('Media items', 'Processed', '3');
+});
+
+it('shows message when no media items found', function () {
+    Conversion::register('thumb', function ($image) {
+        return $image->resize(200, 200);
+    });
+
+    $this->artisan('mediaman:generate-conversions', [
+        '--conversion' => 'thumb',
+        '--media' => '9999',
+    ])
+        ->expectsOutputToContain('No media items found')
+        ->assertExitCode(0);
+});
+
+it('dispatches PerformConversions job when --queue is used', function () {
+    Queue::fake();
+
+    Conversion::register('thumb', function ($image) {
+        return $image->resize(200, 200);
+    });
+
+    MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $out = captureGenerateConversionsOutput([
+        '--conversion' => 'thumb',
+        '--queue' => true,
+    ]);
+
+    expect($out)->toContain('Dispatched', '1', 'queued');
+
+    Queue::assertPushed(PerformConversions::class, 1);
+});
+
+it('filters by collection name', function () {
+    Conversion::register('thumb', function ($image) {
+        return $image->resize(200, 200);
+    });
+
+    MediaUploader::source(UploadedFile::fake()->image('a.jpg'))
+        ->useCollection('Blog')->upload();
+    MediaUploader::source(UploadedFile::fake()->image('b.jpg'))->upload();
+
+    $out = captureGenerateConversionsOutput([
+        '--conversion' => 'thumb',
+        '--collection' => 'Blog',
+        '--force' => true,
+    ]);
+
+    expect($out)->toContain('Media items', 'Processed', '1');
+});
+
+it('handles multiple conversion names', function () {
+    Conversion::register('thumb', function ($image) {
+        return $image->resize(200, 200);
+    });
+    Conversion::register('cover', function ($image) {
+        return $image->resize(800, 600)->encodeUsingFormat(Format::JPEG);
+    });
+
+    MediaUploader::source(UploadedFile::fake()->image('photo.jpg'))->upload();
+
+    $out = captureGenerateConversionsOutput([
+        '--conversion' => 'thumb,cover',
+        '--force' => true,
+    ]);
+
+    expect($out)->toContain('Conversions', 'thumb, cover', 'Processed', '1');
+});
+
+it('fails with invalid --media range (from > to)', function () {
+    Conversion::register('thumb', function ($image) {
+        return $image->resize(200, 200);
+    });
+
+    $this->artisan('mediaman:generate-conversions', [
+        '--conversion' => 'thumb',
+        '--media' => '5..1',
+    ])
+        ->expectsOutputToContain('Invalid --media value')
+        ->assertExitCode(1);
+});


### PR DESCRIPTION
## Summary

- Add `mediaman:generate-conversions` artisan command
- Accepts `--conversion` (required), `--media`, `--collection`, `--force`, `--queue`
- `--media` supports IDs and ranges (e.g. `1,3,5..10`)
- Doctor-style output: aggregated counts per status, media IDs on errors
- Idempotent by default (skips existing conversions); `--force` overwrites

## Test plan

- [x] `composer test` — 591/591 passing
- [x] `composer analyse` — clean
- [x] Manual smoke: `mediaman:generate-conversions --conversion thumb --force` on a fresh app
- [x] Manual smoke: run without `--force`, verify existing conversions skipped + reported
- [x] Manual smoke: `--media="1..50"` processes 50 media items
- [x] Manual smoke: `--media="1,5..10,15"` processes mixed IDs and ranges
- [x] Manual smoke: `--queue` dispatches jobs instead of processing inline