### PR TITLE
Fix file deletion to respect soft deletes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `emaia/laravel-mediaman` will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- File deletion is now **soft-delete aware**. The `Media` model's `deleted` observer fires on both soft and force deletes, so a custom `Media` subclass using Laravel's `SoftDeletes` previously had its on-disk directory wiped on a plain `$media->delete()` — leaving the soft-deleted record pointing at missing files and making `restore()` useless. The observer now skips file removal (and the `MediaDeleted` event) on a soft delete, and only deletes the directory on a force delete (`forceDelete()`) or on a model without soft deletes. The base `Media` model has no `SoftDeletes` trait, so its behavior is unchanged. See [Configuration → Custom models](docs/configuration.md#uuid-primary-keys).
+
 ## [2.17.0] — 2026-06-19
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -305,7 +305,39 @@ class Media extends BaseMedia
 }
 ```
 
-You'll also need a custom migration with `uuid` columns instead of `bigIncrements`. Publish and adjust.
+You'll also need a custom migration with `uuid` columns instead of `bigIncrements`. Publish and adjust. The media key flows through both pivots, so change them too:
+
+```php
+// media table
+$table->uuid('id')->primary();          // was: bigIncrements('id')
+
+// mediaman_collection_media + mediaman_mediables
+$table->foreignUuid('media_id');         // was: unsignedBigInteger('media_id')
+```
+
+The obfuscated storage path works unchanged — `DefaultPathGenerator` builds the directory from `$media->getKey()`, and `HasUuids` generates the key before the row is saved (and before the file is stored).
+
+### Soft deletes
+
+```php
+use Emaia\MediaMan\Models\Media as BaseMedia;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Media extends BaseMedia
+{
+    use SoftDeletes;
+}
+```
+
+Add the `deleted_at` column to the media table in your custom migration (`$table->softDeletes();`).
+
+File deletion is soft-delete aware: a soft delete (`$media->delete()`) keeps the files on disk so `restore()` stays functional, and **does not** fire the `MediaDeleted` event. The on-disk directory is removed only on a force delete (`$media->forceDelete()`) or on a model without the `SoftDeletes` trait.
+
+#### Effect on `getMedia()` and channel relations
+
+> **Soft-deleted media drop out of `getMedia()` automatically.** The `SoftDeletes` global scope filters the underlying relation query, so a soft-deleted record becomes invisible to `$model->getMedia('channel')`, `getFirstMedia()`, `getMediaUrl()`, and the rest of the `HasMedia` trait — even though the pivot row still references it. Use `withTrashed()` on a manual query (`Media::withTrashed()->whereIn('id', $ids)->get()`) when you need to surface trashed records explicitly. Restoring (`$media->restore()`) brings the record back into all channel queries automatically.
+
+`HasUuids` and `SoftDeletes` compose — add both traits to the same custom model when you want UUID keys and soft deletes together.
 
 ## Table names
 

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -72,6 +72,13 @@ class Media extends Model implements Attachable
     public static function booted(): void
     {
         static::deleted(static function ($media) {
+            // Respect soft deletes: a soft delete fires the `deleted` event too,
+            // but the files must survive so a later restore() keeps working.
+            // Only a force delete (or a model without soft deletes) removes files.
+            if (method_exists($media, 'isForceDeleting') && ! $media->isForceDeleting()) {
+                return;
+            }
+
             // delete the media directory
             $deleted = Storage::disk($media->disk)->deleteDirectory($media->getDirectory());
             // if failed, try deleting the file then

--- a/tests/Feature/SoftDeleteFileRetentionTest.php
+++ b/tests/Feature/SoftDeleteFileRetentionTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use Emaia\MediaMan\Events\MediaDeleted;
+use Emaia\MediaMan\MediaUploader;
+use Emaia\MediaMan\Tests\Models\SoftDeletingMedia;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+
+function useSoftDeletingMedia(): void
+{
+    Config::set('mediaman.models.media', SoftDeletingMedia::class);
+
+    Schema::table(config('mediaman.tables.media'), function ($table) {
+        $table->softDeletes();
+    });
+}
+
+it('removes files on delete for media without soft deletes', function () {
+    $media = MediaUploader::source($this->fileOne)
+        ->useDisk('default')
+        ->upload();
+
+    expect(Storage::disk('default')->exists($media->getPath()))->toBeTrue();
+
+    Event::fake([MediaDeleted::class]);
+
+    $media->delete();
+
+    Storage::disk('default')->assertMissing($media->getPath());
+    Event::assertDispatched(MediaDeleted::class);
+});
+
+it('preserves files on soft delete', function () {
+    useSoftDeletingMedia();
+
+    $media = MediaUploader::source($this->fileOne)
+        ->useDisk('default')
+        ->upload();
+
+    expect($media)->toBeInstanceOf(SoftDeletingMedia::class)
+        ->and(Storage::disk('default')->exists($media->getPath()))->toBeTrue();
+
+    Event::fake([MediaDeleted::class]);
+
+    $media->delete();
+
+    expect(Storage::disk('default')->exists($media->getPath()))->toBeTrue()
+        ->and($media->trashed())->toBeTrue()
+        ->and(SoftDeletingMedia::withTrashed()->find($media->id))->not->toBeNull();
+
+    Event::assertNotDispatched(MediaDeleted::class);
+});
+
+it('removes files on force delete of soft deleting media', function () {
+    useSoftDeletingMedia();
+
+    $media = MediaUploader::source($this->fileOne)
+        ->useDisk('default')
+        ->upload();
+
+    expect(Storage::disk('default')->exists($media->getPath()))->toBeTrue();
+
+    Event::fake([MediaDeleted::class]);
+
+    $media->forceDelete();
+
+    Storage::disk('default')->assertMissing($media->getPath());
+
+    expect(SoftDeletingMedia::withTrashed()->find($media->id))->toBeNull();
+    Event::assertDispatched(MediaDeleted::class);
+});
+
+it('restores soft-deleted media with files still on disk', function () {
+    useSoftDeletingMedia();
+
+    $media = MediaUploader::source($this->fileOne)
+        ->useDisk('default')
+        ->upload();
+
+    $path = $media->getPath();
+
+    $media->delete();
+
+    expect($media->trashed())->toBeTrue()
+        ->and(Storage::disk('default')->exists($path))->toBeTrue();
+
+    $media->restore();
+
+    expect($media->trashed())->toBeFalse()
+        ->and(Storage::disk('default')->exists($path))->toBeTrue()
+        ->and(SoftDeletingMedia::find($media->id))->not->toBeNull();
+});

--- a/tests/Models/SoftDeletingMedia.php
+++ b/tests/Models/SoftDeletingMedia.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Emaia\MediaMan\Tests\Models;
+
+use Emaia\MediaMan\Models\Media;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class SoftDeletingMedia extends Media
+{
+    use SoftDeletes;
+}


### PR DESCRIPTION
## Summary

- Make the `Media` model's `deleted` observer **soft-delete aware**: it fires on both soft and force deletes, so a custom `Media` subclass using `SoftDeletes` previously had its on-disk directory wiped on a plain `$media->delete()`, leaving the record pointing at missing files and making `restore()` useless.
- The observer now **skips file removal and the `MediaDeleted` event on a soft delete**, deleting the directory only on a force delete (`forceDelete()`) or on a model without the `SoftDeletes` trait. The base `Media` model has no `SoftDeletes` trait, so its behavior is unchanged (zero BC).
- Add a `SoftDeletingMedia` test fixture and a retention test covering hard delete, soft delete, force delete, and restore.
- Document soft-delete behavior, its effect on `getMedia()`/channel relations, and the UUID pivot migration in `docs/configuration.md`.

## Test plan

- [ ] `composer test` — full suite green, incl. new `SoftDeleteFileRetentionTest` (4 passing)
- [ ] `composer analyse` (phpstan) — no errors; the `method_exists()` guard narrows `isForceDeleting()` for larastan
- [ ] `vendor/bin/pint --test` — clean
- [ ] Manual smoke: in an app with a custom `Media` model using `SoftDeletes`, upload a file, `$media->delete()`, confirm the file **stays** on disk and the record is `trashed()`; then `$media->restore()` and confirm the URL still resolves.
- [ ] Manual smoke: on the same model, `$media->forceDelete()` and confirm the on-disk directory is removed and `MediaDeleted` fires.
- [ ] Manual smoke: with the **default** `Media` model (no soft deletes), `$media->delete()` still removes files and fires `MediaDeleted` (regression).
