### PR TITLE
Expose forgetMediaCache as public fluent helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `emaia/laravel-mediaman` will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `HasMedia::forgetMediaCache(?string $channel = null): self` — public escape hatch to invalidate the in-memory media cache from outside the trait. The cache is cleared automatically by every mutation the trait owns (`attachMedia`, `syncMedia`, `detachMedia`, `setMediaOrder`, `clearMediaChannel`), but callers had no way to react when an external mutation — a queued job on the `sync` driver reusing the same model instance, a raw `DB::table()` insert, a sibling relation refresh — left the cache stale. Passing a channel clears that channel plus the all-channels snapshot (which would otherwise still include the channel's media); passing `null` clears every channel. Returns `$this` so it chains fluently. See [Models → Cache invalidation](docs/models.md#cache-invalidation).
+
 ## [2.17.2] — 2026-06-20
 
 ### Fixed

--- a/docs/api.md
+++ b/docs/api.md
@@ -261,6 +261,7 @@ Public surface of the package, organized by class/trait. Each entry links back t
 | `detachMedia($media = null): ?int`                                                                                                 | Detach specific media (or all when `null`).                                                     |
 | `clearMediaChannel(string $channel = 'default'): void`                                                                             | Detach all in a channel.                                                                        |
 | `setMediaOrder(array $ids, string $channel = 'default'): void`                                                                     | Reorder positions in a transaction. Throws `InvalidArgumentException` if any id isn't attached. |
+| `forgetMediaCache(?string $channel = null): self`                                                                                  | Invalidate the in-memory cache for a channel, or every channel when `null`. Fluent.             |
 
 ### Channel registration
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -70,6 +70,19 @@ $post->detachMedia();               // detach all media from all channels
 $post->clearMediaChannel('gallery'); // detach all media in a specific channel
 ```
 
+### Cache invalidation
+
+`getMedia()` results are cached per-instance to avoid hitting the database on repeat reads inside the same request. The cache is invalidated automatically whenever the trait mutates the pivot — `attachMedia`, `syncMedia`, `detachMedia`, `setMediaOrder`, and `clearMediaChannel` all clear the relevant entries.
+
+If something *outside* the trait changes the pivot — a queued job on the `sync` driver reusing the same model instance, a raw `DB::table()` insert, a sibling relation refresh — the cache stays stale until you tell it otherwise. `forgetMediaCache()` is the escape hatch:
+
+```php
+$post->forgetMediaCache('gallery');  // clear one channel
+$post->forgetMediaCache();           // clear every channel
+```
+
+Clearing a specific channel also invalidates the all-channels (`getMedia(null)`) snapshot, since it includes that channel's media. Returns `$this` so it chains fluently.
+
 ## `getFirst*` and `getLast*` helpers
 
 For the common single-image case (avatars, cover photos), prefer the dedicated helpers — they're shorter and read better.

--- a/src/Traits/HasMedia.php
+++ b/src/Traits/HasMedia.php
@@ -348,15 +348,8 @@ trait HasMedia
     }
 
     /**
-     * Public escape hatch to invalidate the in-memory media cache from outside
-     * the trait. Useful when an external mutation (a queued job on the `sync`
-     * driver reusing the same model instance, a manual DB update, a sibling
-     * relation refresh) leaves the cache stale and the caller has no other
-     * signal to react to.
-     *
-     * Passing a channel name only clears that channel's cache (plus the
-     * all-channels snapshot, which would otherwise still contain the channel's
-     * stale media). Passing `null` clears every channel.
+     * Invalidate the in-memory media cache from outside the trait. Pass a
+     * channel name to clear that channel only, or null to clear every channel.
      */
     public function forgetMediaCache(?string $channel = null): self
     {

--- a/src/Traits/HasMedia.php
+++ b/src/Traits/HasMedia.php
@@ -348,6 +348,24 @@ trait HasMedia
     }
 
     /**
+     * Public escape hatch to invalidate the in-memory media cache from outside
+     * the trait. Useful when an external mutation (a queued job on the `sync`
+     * driver reusing the same model instance, a manual DB update, a sibling
+     * relation refresh) leaves the cache stale and the caller has no other
+     * signal to react to.
+     *
+     * Passing a channel name only clears that channel's cache (plus the
+     * all-channels snapshot, which would otherwise still contain the channel's
+     * stale media). Passing `null` clears every channel.
+     */
+    public function forgetMediaCache(?string $channel = null): self
+    {
+        $this->clearMediaCache($channel);
+
+        return $this;
+    }
+
+    /**
      * Parse the media id's from the mixed input.
      *
      * @param  mixed  $media

--- a/tests/Feature/ForgetMediaCacheTest.php
+++ b/tests/Feature/ForgetMediaCacheTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Emaia\MediaMan\MediaUploader;
+use Emaia\MediaMan\Tests\Models\Subject;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+
+beforeEach(function () {
+    $this->subject = Subject::create();
+
+    $this->mediaA = MediaUploader::source(UploadedFile::fake()->image('a.jpg'))->upload();
+    $this->mediaB = MediaUploader::source(UploadedFile::fake()->image('b.jpg'))->upload();
+
+    $this->subject->attachMedia($this->mediaA->getKey(), 'default');
+    $this->subject->attachMedia($this->mediaB->getKey(), 'gallery');
+});
+
+it('exposes a fluent forgetMediaCache that returns the model', function () {
+    expect($this->subject->forgetMediaCache())->toBe($this->subject)
+        ->and($this->subject->forgetMediaCache('gallery'))->toBe($this->subject);
+});
+
+it('forces the next getMedia call to hit the database when called without args', function () {
+    // Prime the cache.
+    $this->subject->getMedia('default');
+    $this->subject->getMedia('gallery');
+
+    $this->subject->forgetMediaCache();
+
+    DB::enableQueryLog();
+
+    $this->subject->getMedia('default');
+    $this->subject->getMedia('gallery');
+
+    // Two channel reads → two SELECTs against the pivot, proving the cache
+    // was effectively cleared for both keys.
+    expect(DB::getQueryLog())->toHaveCount(2);
+
+    DB::disableQueryLog();
+});
+
+it('forces a refetch only for the targeted channel when called with one', function () {
+    // Prime caches for both channels.
+    $this->subject->getMedia('default');
+    $this->subject->getMedia('gallery');
+
+    $this->subject->forgetMediaCache('gallery');
+
+    DB::enableQueryLog();
+
+    $this->subject->getMedia('default');  // still cached → no SELECT
+    $this->subject->getMedia('gallery');  // cleared → 1 SELECT
+
+    expect(DB::getQueryLog())->toHaveCount(1);
+
+    DB::disableQueryLog();
+});
+
+it('surfaces fresh data after an external sync-driver job mutates the pivot', function () {
+    // Prime: 1 item in gallery.
+    expect($this->subject->getMedia('gallery'))->toHaveCount(1);
+
+    // Simulate an external mutation (queued job on sync driver, another
+    // process sharing the same Eloquent instance, manual DB write…). The
+    // cache is now stale.
+    $mediaC = MediaUploader::source(UploadedFile::fake()->image('c.jpg'))->upload();
+
+    DB::table(config('mediaman.tables.mediables'))->insert([
+        'mediable_type' => $this->subject->getMorphClass(),
+        'mediable_id' => $this->subject->getKey(),
+        'media_id' => $mediaC->getKey(),
+        'channel' => 'gallery',
+        'order_column' => 1,
+    ]);
+
+    // Without invalidation the cache returns the stale single-item snapshot.
+    expect($this->subject->getMedia('gallery'))->toHaveCount(1);
+
+    // After forgetMediaCache the next read sees the externally-inserted row.
+    $this->subject->forgetMediaCache('gallery');
+
+    expect($this->subject->getMedia('gallery'))->toHaveCount(2);
+});


### PR DESCRIPTION
## Summary

- **`feat:` public `HasMedia::forgetMediaCache()` escape hatch** — wraps the existing protected `clearMediaCache` so callers can invalidate the in-memory media cache from outside the trait.
- Internal mutations (`attachMedia`/`syncMedia`/`detachMedia`/`setMediaOrder`/`clearMediaChannel`) already clear the cache automatically; the new method covers the cases that bypass the trait — queued jobs on the `sync` driver reusing the same model instance, raw `DB::table()` inserts, sibling relation refresh.
- Channel arg clears the channel plus the all-channels snapshot (which would otherwise still include the channel's media); `null` clears every channel.
- Returns `$this` for fluent chaining.

## Test plan

- [x] `composer test` — 638/639 passing (1 pre-existing skip)
- [x] `vendor/bin/phpstan analyse` — 0 errors
- [x] `vendor/bin/pint --test` — passed
- [x] New `tests/Feature/ForgetMediaCacheTest.php` covers:
  - Fluent return
  - `forgetMediaCache()` forces both channels to refetch
  - `forgetMediaCache('gallery')` only refetches `gallery`, leaves `default` cached
  - Detects an externally-inserted pivot row that pre-cache would have missed