### PR TITLE
Dispatch MediaPrunedFromCollection event on auto-prune

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `emaia/laravel-mediaman` will be documented in this file.
 
 ### Added
 
+- `MediaPrunedFromCollection` event — dispatched by `MediaCollection::enforceMaxItems()` whenever the cap configured via `onlyKeepLatest()` / `singleFile()` causes older media to be detached. Carries `$event->collection` and `$event->detachedMediaIds` so listeners can record an audit entry, notify the owning user, or clean up downstream state. Auto-prune itself is unchanged — the Media records are still only detached, never deleted — the event just makes it observable. See [Collections → Auto-prune oldest](docs/collections.md#auto-prune-oldest).
 - `HasMedia::forgetMediaCache(?string $channel = null): self` — public escape hatch to invalidate the in-memory media cache from outside the trait. The cache is cleared automatically by every mutation the trait owns (`attachMedia`, `syncMedia`, `detachMedia`, `setMediaOrder`, `clearMediaChannel`), but callers had no way to react when an external mutation — a queued job on the `sync` driver reusing the same model instance, a raw `DB::table()` insert, a sibling relation refresh — left the cache stale. Passing a channel clears that channel plus the all-channels snapshot (which would otherwise still include the channel's media); passing `null` clears every channel. Returns `$this` so it chains fluently. See [Models → Cache invalidation](docs/models.md#cache-invalidation).
 
 ## [2.17.2] — 2026-06-20

--- a/docs/api.md
+++ b/docs/api.md
@@ -502,6 +502,7 @@ Broad bucket classification used by `Media::isOfType()` and `$media->type` acces
 |---------------------------------------------------|---------------------------------------------------|
 | `Emaia\MediaMan\Events\MediaUploaded`             | Right after `MediaUploader::upload()`.            |
 | `Emaia\MediaMan\Events\MediaDeleted`              | Right after `Media::delete()`.                    |
+| `Emaia\MediaMan\Events\MediaPrunedFromCollection` | When `enforceMaxItems()` auto-detaches media.     |
 | `Emaia\MediaMan\Events\ConversionCompleted`       | At the end of the conversion queued job.          |
 | `Emaia\MediaMan\Events\ResponsiveImagesGenerated` | At the end of the responsive variants queued job. |
 

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -119,6 +119,18 @@ When a new media pushes the collection above `max_items`, the **oldest** (by `cr
 
 Auto-prune fires from both upload (`MediaUploader::source()->useCollection(...)->upload()`) and direct attach (`$collection->attachMedia($media)`).
 
+Every prune dispatches a `MediaPrunedFromCollection` event carrying the collection and the list of detached media ids — listen if you need an audit log, want to notify the owning user, or care about cleaning up something downstream:
+
+```php
+use Emaia\MediaMan\Events\MediaPrunedFromCollection;
+
+Event::listen(function (MediaPrunedFromCollection $event) {
+    Log::info("Pruned media from {$event->collection->name}", [
+        'detached_ids' => $event->detachedMediaIds,
+    ]);
+});
+```
+
 ### Fluent setters require `->save()`
 
 The setters mutate the model in memory only — call `->save()` to persist (matches Eloquent convention):

--- a/docs/events.md
+++ b/docs/events.md
@@ -9,12 +9,13 @@ MediaMan dispatches Laravel events at key points in the media lifecycle. Listen 
 
 ## Available events
 
-| Event                         | Dispatched when                          | Payload                                  |
-|-------------------------------|------------------------------------------|------------------------------------------|
-| `MediaUploaded`               | A file is uploaded via `MediaUploader`   | `$event->media`                          |
-| `MediaDeleted`                | A media record is deleted                | `$event->media`                          |
-| `ConversionCompleted`         | Image conversions finish (queued job)    | `$event->media`, `$event->conversions`   |
-| `ResponsiveImagesGenerated`   | Responsive variants finish (queued job)  | `$event->media`, `$event->options`       |
+| Event                         | Dispatched when                                                                | Payload                                       |
+|-------------------------------|--------------------------------------------------------------------------------|-----------------------------------------------|
+| `MediaUploaded`               | A file is uploaded via `MediaUploader`                                         | `$event->media`                               |
+| `MediaDeleted`                | A media record is deleted                                                      | `$event->media`                               |
+| `MediaPrunedFromCollection`   | `enforceMaxItems()` auto-detaches older media from a capped collection         | `$event->collection`, `$event->detachedMediaIds` |
+| `ConversionCompleted`         | Image conversions finish (queued job)                                          | `$event->media`, `$event->conversions`        |
+| `ResponsiveImagesGenerated`   | Responsive variants finish (queued job)                                        | `$event->media`, `$event->options`            |
 
 All event classes live under `Emaia\MediaMan\Events`.
 

--- a/src/Events/MediaPrunedFromCollection.php
+++ b/src/Events/MediaPrunedFromCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Emaia\MediaMan\Events;
+
+use Emaia\MediaMan\Models\MediaCollection;
+use Illuminate\Queue\SerializesModels;
+
+class MediaPrunedFromCollection
+{
+    use SerializesModels;
+
+    /**
+     * @param  array<int, int|string>  $detachedMediaIds  Keys of the media detached from the collection.
+     */
+    public function __construct(
+        public MediaCollection $collection,
+        public array $detachedMediaIds,
+    ) {}
+}

--- a/src/Models/MediaCollection.php
+++ b/src/Models/MediaCollection.php
@@ -2,6 +2,7 @@
 
 namespace Emaia\MediaMan\Models;
 
+use Emaia\MediaMan\Events\MediaPrunedFromCollection;
 use Emaia\MediaMan\Exceptions\MediaNotAcceptedByCollection;
 use Emaia\MediaMan\Traits\ResolvesModels;
 use Illuminate\Database\Eloquent\Collection;
@@ -139,8 +140,11 @@ class MediaCollection extends Model
         }
 
         $toDetach = $attached->take($attached->count() - $max);
+        $detachedIds = $toDetach->modelKeys();
 
-        $this->media()->detach($toDetach->modelKeys());
+        $this->media()->detach($detachedIds);
+
+        event(new MediaPrunedFromCollection($this, $detachedIds));
     }
 
     // ─── Attach / Sync / Detach (with hooks) ──────────────────────────

--- a/tests/Feature/MediaPrunedFromCollectionEventTest.php
+++ b/tests/Feature/MediaPrunedFromCollectionEventTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use Emaia\MediaMan\Events\MediaPrunedFromCollection;
+use Emaia\MediaMan\MediaUploader;
+use Emaia\MediaMan\Models\MediaCollection;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Event;
+
+it('dispatches MediaPrunedFromCollection when auto-prune detaches media', function () {
+    Event::fake([MediaPrunedFromCollection::class]);
+
+    $collection = MediaCollection::create(['name' => 'gallery']);
+    $collection->onlyKeepLatest(2)->save();
+
+    $first = MediaUploader::source(UploadedFile::fake()->image('1.jpg'))->upload();
+    $second = MediaUploader::source(UploadedFile::fake()->image('2.jpg'))->upload();
+    $third = MediaUploader::source(UploadedFile::fake()->image('3.jpg'))->upload();
+
+    // Attach in chronological order. The third attach trips the cap and
+    // prunes the oldest one (first).
+    $collection->attachMedia([$first->getKey(), $second->getKey()]);
+
+    Event::assertNotDispatched(MediaPrunedFromCollection::class);
+
+    $collection->attachMedia($third->getKey());
+
+    Event::assertDispatched(MediaPrunedFromCollection::class, function (MediaPrunedFromCollection $event) use ($collection, $first) {
+        return $event->collection->is($collection)
+            && $event->detachedMediaIds === [$first->getKey()];
+    });
+});
+
+it('does not dispatch the event when no media gets pruned', function () {
+    Event::fake([MediaPrunedFromCollection::class]);
+
+    $collection = MediaCollection::create(['name' => 'gallery']);
+    $collection->onlyKeepLatest(5)->save();
+
+    $media = MediaUploader::source(UploadedFile::fake()->image('a.jpg'))->upload();
+    $collection->attachMedia($media);
+
+    Event::assertNotDispatched(MediaPrunedFromCollection::class);
+});
+
+it('does not dispatch the event when the collection has no max_items', function () {
+    Event::fake([MediaPrunedFromCollection::class]);
+
+    $collection = MediaCollection::create(['name' => 'unlimited']);
+
+    $a = MediaUploader::source(UploadedFile::fake()->image('a.jpg'))->upload();
+    $b = MediaUploader::source(UploadedFile::fake()->image('b.jpg'))->upload();
+
+    $collection->attachMedia([$a->getKey(), $b->getKey()]);
+
+    Event::assertNotDispatched(MediaPrunedFromCollection::class);
+});
+
+it('carries every detached id when the cap is exceeded by more than one item', function () {
+    Event::fake([MediaPrunedFromCollection::class]);
+
+    $collection = MediaCollection::create(['name' => 'gallery']);
+    $collection->onlyKeepLatest(2)->save();
+
+    $a = MediaUploader::source(UploadedFile::fake()->image('a.jpg'))->upload();
+    $b = MediaUploader::source(UploadedFile::fake()->image('b.jpg'))->upload();
+    $c = MediaUploader::source(UploadedFile::fake()->image('c.jpg'))->upload();
+    $d = MediaUploader::source(UploadedFile::fake()->image('d.jpg'))->upload();
+
+    // Attach all four at once. The cap is 2, so the two oldest (a and b)
+    // should be pruned in a single batch.
+    $collection->attachMedia([$a->getKey(), $b->getKey(), $c->getKey(), $d->getKey()]);
+
+    Event::assertDispatched(MediaPrunedFromCollection::class, function (MediaPrunedFromCollection $event) use ($a, $b) {
+        return $event->detachedMediaIds === [$a->getKey(), $b->getKey()];
+    });
+});
+
+it('does not delete the detached media records from the library', function () {
+    Event::fake([MediaPrunedFromCollection::class]);
+
+    $collection = MediaCollection::create(['name' => 'gallery']);
+    $collection->onlyKeepLatest(1)->save();
+
+    $first = MediaUploader::source(UploadedFile::fake()->image('1.jpg'))->upload();
+    $second = MediaUploader::source(UploadedFile::fake()->image('2.jpg'))->upload();
+
+    $collection->attachMedia($first);
+    $collection->attachMedia($second);
+
+    Event::assertDispatched(MediaPrunedFromCollection::class);
+
+    // The pruned media is detached from the collection pivot but the row
+    // still lives in the library — this is the long-standing auto-prune
+    // contract, the event just makes it observable.
+    expect($collection->media()->count())->toBe(1)
+        ->and($first->fresh())->not->toBeNull();
+});


### PR DESCRIPTION
## Summary

- **`feat:` `MediaPrunedFromCollection` event** — dispatched by `MediaCollection::enforceMaxItems()` whenever the cap configured via `onlyKeepLatest()` / `singleFile()` causes older media to be detached.
- Payload exposes `$event->collection` (the `MediaCollection` instance) and `$event->detachedMediaIds` (array of detached media keys).
- Auto-prune behavior itself is unchanged — Media records continue to be detached only, never deleted; the event just makes the silent prune observable for audit logs, owner notifications, downstream cleanup.

## Test plan

- [x] `composer test` — 643/644 passing (1 pre-existing skip)
- [x] `vendor/bin/phpstan analyse` — 0 errors
- [x] `vendor/bin/pint --test` — passed
- [x] New `tests/Feature/MediaPrunedFromCollectionEventTest.php` covers:
  - Event fires when auto-prune detaches media
  - Event does not fire when no prune happens (still under cap)
  - Event does not fire when collection has no `max_items`
  - Payload carries every detached id when the cap is exceeded by more than one
  - Detached media records survive in the library (not deleted)